### PR TITLE
Remove information about exact memory usage numbers from the error message.

### DIFF
--- a/c-api/tests/src/test.c
+++ b/c-api/tests/src/test.c
@@ -1363,7 +1363,7 @@ static void test_memory_limiting() {
 
             cool_thing_str_t *msg = cool_thing_take_last_error();
 
-            str_eq(msg, "Memory limit of 5 bytes has been exceeded: 176 bytes were used.");
+            str_eq(msg, "The memory limit has been exceeded.");
             cool_thing_str_free(*msg);
         },
     max_memory);

--- a/src/memory/arena.rs
+++ b/src/memory/arena.rs
@@ -84,13 +84,7 @@ mod tests {
 
         let err = arena.append(&[11]).unwrap_err();
 
-        assert_eq!(
-            err,
-            MemoryLimitExceededError {
-                current_usage: 11,
-                max: 10
-            }
-        );
+        assert_eq!(err, MemoryLimitExceededError);
     }
 
     #[test]
@@ -116,13 +110,7 @@ mod tests {
 
         let err = arena.init_with(&[1, 2, 3, 4, 5, 6, 7]).unwrap_err();
 
-        assert_eq!(
-            err,
-            MemoryLimitExceededError {
-                current_usage: 7,
-                max: 5
-            }
-        );
+        assert_eq!(err, MemoryLimitExceededError);
     }
 
     #[test]

--- a/src/memory/limited_vec.rs
+++ b/src/memory/limited_vec.rs
@@ -134,13 +134,7 @@ mod tests {
 
         let err = vector.push(3).unwrap_err();
 
-        assert_eq!(
-            err,
-            MemoryLimitExceededError {
-                current_usage: 3,
-                max: 2
-            }
-        );
+        assert_eq!(err, MemoryLimitExceededError);
     }
 
     #[test]

--- a/src/memory/limiter.rs
+++ b/src/memory/limiter.rs
@@ -9,14 +9,8 @@ pub type SharedMemoryLimiter = Rc<RefCell<MemoryLimiter>>;
 ///
 /// [`MemorySettings`]: ../struct.MemorySettings.html
 #[derive(Error, Debug, PartialEq, Copy, Clone)]
-#[error("Memory limit of {max} bytes has been exceeded: {current_usage} bytes were used.")]
-pub struct MemoryLimitExceededError {
-    /// The amount of memory requested by the rewriter that exceeded the limit.
-    pub current_usage: usize,
-
-    /// Current memory limit.
-    pub max: usize,
-}
+#[error("The memory limit has been exceeded.")]
+pub struct MemoryLimitExceededError;
 
 #[derive(Debug)]
 pub struct MemoryLimiter {
@@ -42,10 +36,7 @@ impl MemoryLimiter {
         self.current_usage += byte_count;
 
         if self.current_usage > self.max {
-            Err(MemoryLimitExceededError {
-                current_usage: self.current_usage,
-                max: self.max,
-            })
+            Err(MemoryLimitExceededError)
         } else {
             Ok(())
         }
@@ -86,13 +77,7 @@ mod tests {
 
         let err = limiter.increase_usage(15).unwrap_err();
 
-        assert_eq!(
-            err,
-            MemoryLimitExceededError {
-                current_usage: 19,
-                max: 10
-            }
-        );
+        assert_eq!(err, MemoryLimitExceededError);
     }
 
     #[test]

--- a/src/rewriter/mod.rs
+++ b/src/rewriter/mod.rs
@@ -588,20 +588,13 @@ mod tests {
             // make sure to overflow it.
             let chunk_1 = format!("<img alt=\"{}", "l".repeat(MAX / 2));
             let chunk_2 = format!("{}\" />", "r".repeat(MAX / 2));
-            let mem_used = chunk_1.len() + chunk_2.len();
 
             rewriter.write(chunk_1.as_bytes()).unwrap();
 
             let write_err = rewriter.write(chunk_2.as_bytes()).unwrap_err();
 
             match write_err {
-                RewritingError::MemoryLimitExceeded(e) => assert_eq!(
-                    e,
-                    MemoryLimitExceededError {
-                        current_usage: mem_used,
-                        max: MAX
-                    }
-                ),
+                RewritingError::MemoryLimitExceeded(e) => assert_eq!(e, MemoryLimitExceededError),
                 _ => panic!("{}", write_err),
             }
         }


### PR DESCRIPTION
This was motivated by testing convienience and security considerations that current message creates for Cloudflare Workers.