### PR TITLE
Add handlers for when the rewriting is finished.

### DIFF
--- a/c-api/include/lol_html.h
+++ b/c-api/include/lol_html.h
@@ -659,6 +659,12 @@ void lol_html_element_user_data_set(
 // Returns user data attached to the text chunk.
 void *lol_html_element_user_data_get(const lol_html_element_t *element);
 
+// Inserts the content at the end of the document, either as raw text or as HTML.
+//
+// The content should be a valid UTF-8 string.
+//
+// Returns 0 if successful, and -1 otherwise. The actual error message
+// can be obtained using the `lol_html_take_last_error` function.
 int lol_html_doc_end_append(
     lol_html_doc_end_t *doc_end,
     const char *content,

--- a/c-api/include/lol_html.h
+++ b/c-api/include/lol_html.h
@@ -104,7 +104,8 @@ typedef lol_html_rewriter_directive_t (*lol_html_element_handler_t)(
 );
 
 typedef lol_html_rewriter_directive_t (*lol_html_doc_end_handler_t)(
-    lol_html_doc_end_t *doc_end
+    lol_html_doc_end_t *doc_end,
+    void *user_data
 );
 
 // Selector
@@ -112,7 +113,7 @@ typedef lol_html_rewriter_directive_t (*lol_html_doc_end_handler_t)(
 
 // Parses given CSS selector string.
 //
-// Returns NULL if parsing error occures. The actual error message
+// Returns NULL if parsing error occurs. The actual error message
 // can be obtained using `lol_html_take_last_error` function.
 //
 // WARNING: Selector SHOULD NOT be deallocated if there are any active rewriter
@@ -156,7 +157,8 @@ void lol_html_rewriter_builder_add_document_content_handlers(
     void *comment_handler_user_data,
     lol_html_text_handler_handler_t text_handler,
     void *text_handler_user_data,
-    lol_html_doc_end_handler_t doc_end_handler
+    lol_html_doc_end_handler_t doc_end_handler,
+    void *doc_end_user_data
 );
 
 // Adds element content handlers to the builder for the
@@ -173,7 +175,7 @@ void lol_html_rewriter_builder_add_document_content_handlers(
 // passed to the handler on each invocation along with the rewritable
 // unit argument.
 //
-// If any of handlers return LOL_HTML_STOP directive is then rewriting
+// If any of handlers return LOL_HTML_STOP directive then rewriting
 // stops immediately and `write()` or `end()` of the rewriter methods
 // return an error code.
 //

--- a/c-api/include/lol_html.h
+++ b/c-api/include/lol_html.h
@@ -22,6 +22,7 @@ extern "C" {
 typedef struct lol_html_HtmlRewriterBuilder lol_html_rewriter_builder_t;
 typedef struct lol_html_HtmlRewriter lol_html_rewriter_t;
 typedef struct lol_html_Doctype lol_html_doctype_t;
+typedef struct lol_html_DocumentEnd lol_html_doc_end_t;
 typedef struct lol_html_Comment lol_html_comment_t;
 typedef struct lol_html_TextChunk lol_html_text_chunk_t;
 typedef struct lol_html_Element lol_html_element_t;
@@ -75,7 +76,7 @@ lol_html_rewriter_builder_t *lol_html_rewriter_builder_new();
 // Content handlers
 //---------------------------------------------------------------------
 // Rewriter directive that should be returned from each content handler.
-// If LOL_HTML_STOP directive is returned then rewriting stops immidiately
+// If LOL_HTML_STOP directive is returned then rewriting stops immediately
 // and `write()` or `end()` methods of the rewriter return an error code.
 typedef enum {
     LOL_HTML_CONTINUE,
@@ -100,6 +101,10 @@ typedef lol_html_rewriter_directive_t (*lol_html_text_handler_handler_t)(
 typedef lol_html_rewriter_directive_t (*lol_html_element_handler_t)(
     lol_html_element_t *element,
     void *user_data
+);
+
+typedef lol_html_rewriter_directive_t (*lol_html_doc_end_handler_t)(
+    lol_html_doc_end_t *doc_end
 );
 
 // Selector
@@ -137,8 +142,8 @@ void lol_html_selector_free(lol_html_selector_t *selector);
 // passed to the handler on each invocation along with the rewritable
 // unit argument.
 //
-// If any of handlers return LOL_HTML_STOP directive is then rewriting
-// stops immidiately and `write()` or `end()` of the rewriter methods
+// If any of handlers return LOL_HTML_STOP directive then rewriting
+// stops immediately and `write()` or `end()` of the rewriter methods
 // return an error code.
 //
 // WARNING: Pointers passed to handlers are valid only during the
@@ -150,7 +155,8 @@ void lol_html_rewriter_builder_add_document_content_handlers(
     lol_html_comment_handler_t comment_handler,
     void *comment_handler_user_data,
     lol_html_text_handler_handler_t text_handler,
-    void *text_handler_user_data
+    void *text_handler_user_data,
+    lol_html_doc_end_handler_t doc_end_handler
 );
 
 // Adds element content handlers to the builder for the
@@ -168,7 +174,7 @@ void lol_html_rewriter_builder_add_document_content_handlers(
 // unit argument.
 //
 // If any of handlers return LOL_HTML_STOP directive is then rewriting
-// stops immidiately and `write()` or `end()` of the rewriter methods
+// stops immediately and `write()` or `end()` of the rewriter methods
 // return an error code.
 //
 // Returns 0 in case of success and -1 otherwise. The actual error message
@@ -650,6 +656,13 @@ void lol_html_element_user_data_set(
 
 // Returns user data attached to the text chunk.
 void *lol_html_element_user_data_get(const lol_html_element_t *element);
+
+int lol_html_doc_end_append(
+    lol_html_doc_end_t *doc_end,
+    const char *content,
+    size_t content_len,
+    bool is_html
+);
 
 #if defined(__cplusplus)
 }  // extern C

--- a/c-api/src/document_end.rs
+++ b/c-api/src/document_end.rs
@@ -1,0 +1,11 @@
+use super::*;
+
+#[no_mangle]
+pub extern "C" fn lol_html_doc_end_append(
+    document_end: *mut DocumentEnd,
+    content: *const c_char,
+    content_len: size_t,
+    is_html: bool,
+) -> c_int {
+    content_insertion_fn_body! { document_end.append(content, content_len, is_html) }
+}

--- a/c-api/src/lib.rs
+++ b/c-api/src/lib.rs
@@ -117,6 +117,7 @@ macro_rules! get_user_data {
 
 mod comment;
 mod doctype;
+mod document_end;
 mod element;
 mod errors;
 mod rewriter;

--- a/c-api/src/rewriter_builder.rs
+++ b/c-api/src/rewriter_builder.rs
@@ -130,6 +130,7 @@ pub extern "C" fn lol_html_rewriter_builder_add_document_content_handlers(
     text_handler: Option<TextHandler>,
     text_handler_user_data: *mut c_void,
     document_end_handler: Option<DocumentEndHandler>,
+    document_end_handler_user_data: *mut c_void,
 ) {
     let builder = to_ref_mut!(builder);
 
@@ -137,7 +138,7 @@ pub extern "C" fn lol_html_rewriter_builder_add_document_content_handlers(
         doctype: ExternHandler::new(doctype_handler, doctype_handler_user_data),
         comments: ExternHandler::new(comments_handler, comments_handler_user_data),
         text: ExternHandler::new(text_handler, text_handler_user_data),
-        end: ExternHandler::new(document_end_handler, std::ptr::null_mut()),
+        end: ExternHandler::new(document_end_handler, document_end_handler_user_data),
     };
 
     builder.document_content_handlers.push(handlers);

--- a/c-api/src/rewriter_builder.rs
+++ b/c-api/src/rewriter_builder.rs
@@ -11,6 +11,7 @@ type ElementHandler = unsafe extern "C" fn(*mut Element, *mut c_void) -> Rewrite
 type DoctypeHandler = unsafe extern "C" fn(*mut Doctype, *mut c_void) -> RewriterDirective;
 type CommentsHandler = unsafe extern "C" fn(*mut Comment, *mut c_void) -> RewriterDirective;
 type TextHandler = unsafe extern "C" fn(*mut TextChunk, *mut c_void) -> RewriterDirective;
+type DocumentEndHandler = unsafe extern "C" fn(*mut DocumentEnd, *mut c_void) -> RewriterDirective;
 
 struct ExternHandler<F> {
     func: Option<F>,
@@ -52,6 +53,7 @@ pub struct ExternDocumentContentHandlers {
     doctype: ExternHandler<DoctypeHandler>,
     comments: ExternHandler<CommentsHandler>,
     text: ExternHandler<TextHandler>,
+    end: ExternHandler<DocumentEndHandler>,
 }
 
 impl ExternDocumentContentHandlers {
@@ -61,6 +63,7 @@ impl ExternDocumentContentHandlers {
         add_handler!(handlers, self.doctype);
         add_handler!(handlers, self.comments);
         add_handler!(handlers, self.text);
+        add_handler!(handlers, self.end);
 
         handlers
     }
@@ -126,6 +129,7 @@ pub extern "C" fn lol_html_rewriter_builder_add_document_content_handlers(
     comments_handler_user_data: *mut c_void,
     text_handler: Option<TextHandler>,
     text_handler_user_data: *mut c_void,
+    document_end_handler: Option<DocumentEndHandler>,
 ) {
     let builder = to_ref_mut!(builder);
 
@@ -133,6 +137,7 @@ pub extern "C" fn lol_html_rewriter_builder_add_document_content_handlers(
         doctype: ExternHandler::new(doctype_handler, doctype_handler_user_data),
         comments: ExternHandler::new(comments_handler, comments_handler_user_data),
         text: ExternHandler::new(text_handler, text_handler_user_data),
+        end: ExternHandler::new(document_end_handler, std::ptr::null_mut()),
     };
 
     builder.document_content_handlers.push(handlers);

--- a/c-api/tests/src/test.c
+++ b/c-api/tests/src/test.c
@@ -14,6 +14,7 @@ int run_tests() {
     subtest("Comment API", test_comment_api);
     subtest("Text chunk API", test_text_chunk_api);
     subtest("Element API", element_api_test);
+    subtest("Document end API", document_end_api_test);
     subtest("Memory limiting", test_memory_limiting);
     return done_testing();
 }

--- a/c-api/tests/src/test_comment_api.c
+++ b/c-api/tests/src/test_comment_api.c
@@ -44,6 +44,7 @@ static void test_get_set_comment_text(void *user_data) {
         &get_set_comment_text,
         user_data,
         NULL,
+        NULL,
         NULL
     );
 
@@ -83,6 +84,7 @@ static void test_insert_before_and_after_comment(void *user_data) {
         NULL,
         &insert_before_and_after_comment,
         user_data,
+        NULL,
         NULL,
         NULL
     );
@@ -130,6 +132,7 @@ static void test_get_set_user_data(void *user_data) {
         NULL,
         &get_set_user_data,
         user_data,
+        NULL,
         NULL,
         NULL
     );
@@ -213,6 +216,7 @@ static void test_insert_after_comment(lol_html_selector_t *selector, void *user_
         &insert_after_comment,
         NULL,
         NULL,
+        NULL,
         NULL
     );
 
@@ -258,6 +262,7 @@ static void test_remove_comment(void *user_data) {
         &remove_comment,
         NULL,
         NULL,
+        NULL,
         NULL
     );
 
@@ -285,6 +290,7 @@ static void test_stop(void *user_data) {
         NULL,
         NULL,
         &stop_rewriting,
+        NULL,
         NULL,
         NULL,
         NULL

--- a/c-api/tests/src/test_comment_api.c
+++ b/c-api/tests/src/test_comment_api.c
@@ -45,6 +45,7 @@ static void test_get_set_comment_text(void *user_data) {
         user_data,
         NULL,
         NULL,
+        NULL,
         NULL
     );
 
@@ -84,6 +85,7 @@ static void test_insert_before_and_after_comment(void *user_data) {
         NULL,
         &insert_before_and_after_comment,
         user_data,
+        NULL,
         NULL,
         NULL,
         NULL
@@ -132,6 +134,7 @@ static void test_get_set_user_data(void *user_data) {
         NULL,
         &get_set_user_data,
         user_data,
+        NULL,
         NULL,
         NULL,
         NULL
@@ -217,6 +220,7 @@ static void test_insert_after_comment(lol_html_selector_t *selector, void *user_
         NULL,
         NULL,
         NULL,
+        NULL,
         NULL
     );
 
@@ -263,6 +267,7 @@ static void test_remove_comment(void *user_data) {
         NULL,
         NULL,
         NULL,
+        NULL,
         NULL
     );
 
@@ -290,6 +295,7 @@ static void test_stop(void *user_data) {
         NULL,
         NULL,
         &stop_rewriting,
+        NULL,
         NULL,
         NULL,
         NULL,

--- a/c-api/tests/src/test_doctype_api.c
+++ b/c-api/tests/src/test_doctype_api.c
@@ -45,6 +45,7 @@ static void test_get_doctype_fields(void *user_data) {
         NULL,
         NULL,
         NULL,
+        NULL,
         NULL
     );
 
@@ -94,6 +95,7 @@ static void test_get_user_data(void *user_data) {
         NULL,
         NULL,
         NULL,
+        NULL,
         NULL
     );
 
@@ -124,6 +126,7 @@ static void test_stop(void *user_data) {
     lol_html_rewriter_builder_add_document_content_handlers(
         builder,
         &stop_rewriting,
+        NULL,
         NULL,
         NULL,
         NULL,

--- a/c-api/tests/src/test_doctype_api.c
+++ b/c-api/tests/src/test_doctype_api.c
@@ -46,6 +46,7 @@ static void test_get_doctype_fields(void *user_data) {
         NULL,
         NULL,
         NULL,
+        NULL,
         NULL
     );
 
@@ -96,6 +97,7 @@ static void test_get_user_data(void *user_data) {
         NULL,
         NULL,
         NULL,
+        NULL,
         NULL
     );
 
@@ -126,6 +128,7 @@ static void test_stop(void *user_data) {
     lol_html_rewriter_builder_add_document_content_handlers(
         builder,
         &stop_rewriting,
+        NULL,
         NULL,
         NULL,
         NULL,

--- a/c-api/tests/src/test_document_end_api.c
+++ b/c-api/tests/src/test_document_end_api.c
@@ -3,16 +3,22 @@
 #include "tests.h"
 #include "test_util.h"
 
+static int EXPECTED_USER_DATA = 43;
+
 //-------------------------------------------------------------------------
 EXPECT_OUTPUT(
     append_to_empty_doc_output_sink,
     "<!--appended text-->hello &amp; world",
-    NULL,
-    0
+    &EXPECTED_USER_DATA,
+    sizeof(EXPECTED_USER_DATA)
 );
 
-static lol_html_rewriter_directive_t append_to_empty_doc(lol_html_doc_end_t *doc_end) {
+static lol_html_rewriter_directive_t append_to_empty_doc(
+    lol_html_doc_end_t *doc_end,
+    void *user_data
+) {
     note("Append at at the end of an empty document");
+    ok(*(int*)user_data == EXPECTED_USER_DATA);
 
     const char *append_html = "<!--appended text-->";
     ok(!lol_html_doc_end_append(doc_end, append_html, strlen(append_html), true));
@@ -20,10 +26,10 @@ static lol_html_rewriter_directive_t append_to_empty_doc(lol_html_doc_end_t *doc
     const char *append_text = "hello & world";
     ok(!lol_html_doc_end_append(doc_end, append_text, strlen(append_text), false));
 
-    return lol_html_CONTINUE;
+    return LOL_HTML_CONTINUE;
 }
 
-static void test_append_to_empty_doc() {
+static void test_append_to_empty_doc(void *user_data) {
     lol_html_rewriter_builder_t *builder = lol_html_rewriter_builder_new();
 
     lol_html_rewriter_builder_add_document_content_handlers(
@@ -34,14 +40,15 @@ static void test_append_to_empty_doc() {
         NULL,
         NULL,
         NULL,
-        append_to_empty_doc
+        append_to_empty_doc,
+        user_data
     );
 
     run_rewriter(
         builder,
         "",
         append_to_empty_doc_output_sink,
-        NULL
+        user_data
     );
 }
 
@@ -49,12 +56,16 @@ static void test_append_to_empty_doc() {
 EXPECT_OUTPUT(
     append_at_end_output_sink,
     "<html><div>Hello</div></html><!--appended text-->hello &amp; world",
-    NULL,
-    0
+    &EXPECTED_USER_DATA,
+    sizeof(EXPECTED_USER_DATA)
 );
 
-static lol_html_rewriter_directive_t append_at_end(lol_html_doc_end_t *doc_end) {
+static lol_html_rewriter_directive_t append_at_end(
+    lol_html_doc_end_t *doc_end,
+    void *user_data
+) {
     note("Append at at the end");
+    ok(*(int*)user_data == EXPECTED_USER_DATA);
 
     const char *append_html = "<!--appended text-->";
     ok(!lol_html_doc_end_append(doc_end, append_html, strlen(append_html), true));
@@ -62,10 +73,10 @@ static lol_html_rewriter_directive_t append_at_end(lol_html_doc_end_t *doc_end) 
     const char *append_text = "hello & world";
     ok(!lol_html_doc_end_append(doc_end, append_text, strlen(append_text), false));
 
-    return lol_html_CONTINUE;
+    return LOL_HTML_CONTINUE;
 }
 
-static void test_append_at_end() {
+static void test_append_at_end(void *user_data) {
     lol_html_rewriter_builder_t *builder = lol_html_rewriter_builder_new();
 
     lol_html_rewriter_builder_add_document_content_handlers(
@@ -76,18 +87,21 @@ static void test_append_at_end() {
         NULL,
         NULL,
         NULL,
-        append_at_end
+        append_at_end,
+        user_data
     );
 
     run_rewriter(
         builder,
         "<html><div>Hello</div></html>",
         append_at_end_output_sink,
-        NULL
+        user_data
     );
 }
 
 void document_end_api_test() {
-    test_append_to_empty_doc();
-    test_append_at_end();
+    int user_data = 43;
+
+    test_append_to_empty_doc(&user_data);
+    test_append_at_end(&user_data);
 }

--- a/c-api/tests/src/test_document_end_api.c
+++ b/c-api/tests/src/test_document_end_api.c
@@ -1,0 +1,93 @@
+#include "../../include/lol_html.h"
+#include "deps/picotest/picotest.h"
+#include "tests.h"
+#include "test_util.h"
+
+//-------------------------------------------------------------------------
+EXPECT_OUTPUT(
+    append_to_empty_doc_output_sink,
+    "<!--appended text-->hello &amp; world",
+    NULL,
+    0
+);
+
+static lol_html_rewriter_directive_t append_to_empty_doc(lol_html_doc_end_t *doc_end) {
+    note("Append at at the end of an empty document");
+
+    const char *append_html = "<!--appended text-->";
+    ok(!lol_html_doc_end_append(doc_end, append_html, strlen(append_html), true));
+
+    const char *append_text = "hello & world";
+    ok(!lol_html_doc_end_append(doc_end, append_text, strlen(append_text), false));
+
+    return lol_html_CONTINUE;
+}
+
+static void test_append_to_empty_doc() {
+    lol_html_rewriter_builder_t *builder = lol_html_rewriter_builder_new();
+
+    lol_html_rewriter_builder_add_document_content_handlers(
+        builder,
+        NULL,
+        NULL,
+        NULL,
+        NULL,
+        NULL,
+        NULL,
+        append_to_empty_doc
+    );
+
+    run_rewriter(
+        builder,
+        "",
+        append_to_empty_doc_output_sink,
+        NULL
+    );
+}
+
+//-------------------------------------------------------------------------
+EXPECT_OUTPUT(
+    append_at_end_output_sink,
+    "<html><div>Hello</div></html><!--appended text-->hello &amp; world",
+    NULL,
+    0
+);
+
+static lol_html_rewriter_directive_t append_at_end(lol_html_doc_end_t *doc_end) {
+    note("Append at at the end");
+
+    const char *append_html = "<!--appended text-->";
+    ok(!lol_html_doc_end_append(doc_end, append_html, strlen(append_html), true));
+
+    const char *append_text = "hello & world";
+    ok(!lol_html_doc_end_append(doc_end, append_text, strlen(append_text), false));
+
+    return lol_html_CONTINUE;
+}
+
+static void test_append_at_end() {
+    lol_html_rewriter_builder_t *builder = lol_html_rewriter_builder_new();
+
+    lol_html_rewriter_builder_add_document_content_handlers(
+        builder,
+        NULL,
+        NULL,
+        NULL,
+        NULL,
+        NULL,
+        NULL,
+        append_at_end
+    );
+
+    run_rewriter(
+        builder,
+        "<html><div>Hello</div></html>",
+        append_at_end_output_sink,
+        NULL
+    );
+}
+
+void document_end_api_test() {
+    test_append_to_empty_doc();
+    test_append_at_end();
+}

--- a/c-api/tests/src/test_text_chunk_api.c
+++ b/c-api/tests/src/test_text_chunk_api.c
@@ -52,6 +52,7 @@ static void test_insert_before_and_after_text_chunk(void *user_data) {
         NULL,
         NULL,
         &insert_before_and_after_text_chunk,
+        NULL,
         NULL
     );
 
@@ -95,7 +96,8 @@ static void test_modify_user_data(void *user_data) {
         NULL,
         NULL,
         &modify_user_data,
-        user_data
+        user_data,
+        NULL
     );
 
     run_rewriter(builder, "Hey 42", modify_user_data_output_sink, user_data);
@@ -177,6 +179,7 @@ static void test_insert_after_chunk(void *user_data) {
         NULL,
         NULL,
         &insert_after_chunk,
+        NULL,
         NULL
     );
 
@@ -216,6 +219,7 @@ static void test_remove_chunk(void *user_data) {
         NULL,
         NULL,
         &remove_chunk,
+        NULL,
         NULL
     );
 
@@ -263,6 +267,7 @@ static void test_stop(void *user_data) {
         NULL,
         NULL,
         &stop_rewriting,
+        NULL,
         NULL
     );
 

--- a/c-api/tests/src/test_text_chunk_api.c
+++ b/c-api/tests/src/test_text_chunk_api.c
@@ -53,6 +53,7 @@ static void test_insert_before_and_after_text_chunk(void *user_data) {
         NULL,
         &insert_before_and_after_text_chunk,
         NULL,
+        NULL,
         NULL
     );
 
@@ -97,6 +98,7 @@ static void test_modify_user_data(void *user_data) {
         NULL,
         &modify_user_data,
         user_data,
+        NULL,
         NULL
     );
 
@@ -180,6 +182,7 @@ static void test_insert_after_chunk(void *user_data) {
         NULL,
         &insert_after_chunk,
         NULL,
+        NULL,
         NULL
     );
 
@@ -219,6 +222,7 @@ static void test_remove_chunk(void *user_data) {
         NULL,
         NULL,
         &remove_chunk,
+        NULL,
         NULL,
         NULL
     );
@@ -267,6 +271,7 @@ static void test_stop(void *user_data) {
         NULL,
         NULL,
         &stop_rewriting,
+        NULL,
         NULL,
         NULL
     );

--- a/c-api/tests/src/tests.h
+++ b/c-api/tests/src/tests.h
@@ -9,6 +9,7 @@ void test_doctype_api();
 void test_comment_api();
 void test_text_chunk_api();
 void element_api_test();
+void document_end_api_test();
 void test_memory_limiting();
 
 #endif // TESTS_H

--- a/src/base/bytes.rs
+++ b/src/base/bytes.rs
@@ -77,7 +77,12 @@ macro_rules! impl_replace_byte {
                 Some(pos) => {
                     let replacement = $impls!(@get_replacement tail, pos);
 
-                    $output_handler(&tail[..pos]);
+                    // If pos is 0, tail[..pos] will be empty, thus erroneously interpreted
+                    // as a finalizing chunk.
+                    if pos != 0 {
+                        $output_handler(&tail[..pos]);
+                    }
+
                     $output_handler(&replacement);
                     tail = &tail[pos + 1..];
                 }

--- a/src/base/bytes.rs
+++ b/src/base/bytes.rs
@@ -77,7 +77,7 @@ macro_rules! impl_replace_byte {
                 Some(pos) => {
                     let replacement = $impls!(@get_replacement tail, pos);
 
-                    // If pos is 0, tail[..pos] will be empty, thus erroneously interpreted
+                    // If `pos` is 0, tail[..pos] will be empty, and erroneously interpreted
                     // as a finalizing chunk.
                     if pos != 0 {
                         $output_handler(&tail[..pos]);

--- a/src/base/bytes.rs
+++ b/src/base/bytes.rs
@@ -76,11 +76,10 @@ macro_rules! impl_replace_byte {
             match $impls!(@find tail) {
                 Some(pos) => {
                     let replacement = $impls!(@get_replacement tail, pos);
+                    let chunk = &tail[..pos];
 
-                    // If `pos` is 0, tail[..pos] will be empty, and erroneously interpreted
-                    // as a finalizing chunk.
-                    if pos != 0 {
-                        $output_handler(&tail[..pos]);
+                    if !chunk.is_empty() {
+                        $output_handler(chunk);
                     }
 
                     $output_handler(&replacement);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -52,7 +52,7 @@ pub mod errors {
 /// HTML content descriptors that can be produced and modified by a rewriter.
 pub mod html_content {
     pub use super::rewritable_units::{
-        Attribute, Comment, ContentType, Doctype, Element, TextChunk, UserData,
+        Attribute, Comment, ContentType, Doctype, DocumentEnd, Element, TextChunk, UserData,
     };
 
     pub use super::html::TextType;

--- a/src/rewritable_units/document_end.rs
+++ b/src/rewritable_units/document_end.rs
@@ -73,14 +73,12 @@ mod tests {
             html,
             encoding,
             vec![],
-            vec![
-                end!(|end| {
-                    handler_called = true;
-                    handler(end);
+            vec![end!(|end| {
+                handler_called = true;
+                handler(end);
 
-                    Ok(())
-                }),
-            ],
+                Ok(())
+            })],
         );
 
         assert!(handler_called, "Handler not called.");
@@ -107,7 +105,10 @@ mod tests {
                 end.append("</span>", ContentType::Html);
             });
 
-            assert_eq!(output, "<div><h1>Hεllo</h1></div><span>world&lt;foo&gt;</span>");
+            assert_eq!(
+                output,
+                "<div><h1>Hεllo</h1></div><span>world&lt;foo&gt;</span>"
+            );
         }
     }
 }

--- a/src/rewritable_units/document_end.rs
+++ b/src/rewritable_units/document_end.rs
@@ -111,4 +111,17 @@ mod tests {
             );
         }
     }
+
+    #[test]
+    fn append_content_regression() {
+        // This prevents a regression where the output sink received an empty chunk
+        // before the end of the input stream.
+        for (html, enc) in encoded("") {
+            let output = rewrite_on_end(&html, enc, |end| {
+                end.append("<foo>", ContentType::Text);
+            });
+
+            assert_eq!(output, "&lt;foo&gt;");
+        }
+    }
 }

--- a/src/rewritable_units/document_end.rs
+++ b/src/rewritable_units/document_end.rs
@@ -1,0 +1,56 @@
+use super::mutations::content_to_bytes;
+use super::ContentType;
+
+use encoding_rs::Encoding;
+
+use crate::transform_stream::OutputSink;
+
+/// A rewritable unit that represents the end of the document.
+///
+/// This exposes the [append](#method.append) function that can be used to append content at the
+/// end of the document. The content will only be appended after the rewriter has finished processing
+/// the final chunk.
+pub struct DocumentEnd<'a> {
+    output_sink: &'a mut dyn OutputSink,
+    encoding: &'static Encoding,
+}
+
+impl<'a> DocumentEnd<'a> {
+    pub(crate) fn new(output_sink: &'a mut dyn OutputSink, encoding: &'static Encoding) -> Self {
+        DocumentEnd {
+            output_sink,
+            encoding,
+        }
+    }
+
+    /// Appends `content` at the end of the document.
+    ///
+    /// Subsequent calls to this method append `content` to the previously inserted content.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use lol_html::{end, rewrite_str, RewriteStrSettings};
+    /// use lol_html::html_content::{ContentType, DocumentEnd};
+    ///
+    /// let html = rewrite_str(
+    ///     r#"<div id="foo"><!-- content --></div><img>"#,
+    ///     RewriteStrSettings {
+    ///         document_content_handlers: vec![end!(|end| {
+    ///             end.append("<bar>", ContentType::Html);
+    ///             end.append("<baz>", ContentType::Text);
+    ///             Ok(())
+    ///         })],
+    ///         ..RewriteStrSettings::default()
+    ///     }
+    /// ).unwrap();
+    ///
+    /// assert_eq!(html, r#"<div id="foo"><!-- content --></div><img><bar>&lt;baz&gt;"#);
+    /// ```
+    #[inline]
+    pub fn append(&mut self, content: &str, content_type: ContentType) {
+        content_to_bytes(content, content_type, self.encoding, &mut |c: &[u8]| {
+            self.output_sink.handle_chunk(c)
+        });
+    }
+}

--- a/src/rewritable_units/mod.rs
+++ b/src/rewritable_units/mod.rs
@@ -1,5 +1,6 @@
 use std::any::Any;
 
+pub use self::document_end::*;
 pub use self::element::*;
 pub use self::mutations::{ContentType, Mutations};
 pub use self::tokens::*;
@@ -80,6 +81,7 @@ macro_rules! impl_user_data {
 #[macro_use]
 mod mutations;
 
+mod document_end;
 mod element;
 mod tokens;
 

--- a/src/rewritable_units/mutations.rs
+++ b/src/rewritable_units/mutations.rs
@@ -13,11 +13,11 @@ pub enum ContentType {
 }
 
 #[inline]
-fn content_to_bytes<O: FnMut(&[u8])>(
+pub(super) fn content_to_bytes(
     content: &str,
     content_type: ContentType,
     encoding: &'static Encoding,
-    mut output_handler: O,
+    mut output_handler: &mut dyn FnMut(&[u8]),
 ) {
     let bytes = Bytes::from_str(content, encoding);
 
@@ -54,7 +54,7 @@ impl Mutations {
 
     #[inline]
     pub fn before(&mut self, content: &str, content_type: ContentType) {
-        content_to_bytes(content, content_type, self.encoding, |c| {
+        content_to_bytes(content, content_type, self.encoding, &mut |c| {
             self.content_before.extend_from_slice(c);
         });
     }
@@ -63,7 +63,7 @@ impl Mutations {
     pub fn after(&mut self, content: &str, content_type: ContentType) {
         let mut pos = 0;
 
-        content_to_bytes(content, content_type, self.encoding, |c| {
+        content_to_bytes(content, content_type, self.encoding, &mut |c| {
             self.content_after.splice(pos..pos, c.iter().cloned());
 
             pos += c.len();
@@ -74,7 +74,7 @@ impl Mutations {
     pub fn replace(&mut self, content: &str, content_type: ContentType) {
         let mut replacement = Vec::default();
 
-        content_to_bytes(content, content_type, self.encoding, |c| {
+        content_to_bytes(content, content_type, self.encoding, &mut |c| {
             replacement.extend_from_slice(c);
         });
 

--- a/src/rewriter/rewrite_controller.rs
+++ b/src/rewriter/rewrite_controller.rs
@@ -1,7 +1,7 @@
 use super::handlers_dispatcher::{ContentHandlersDispatcher, SelectorHandlersLocator};
 use super::RewritingError;
 use crate::html::{LocalName, Namespace};
-use crate::rewritable_units::{Token, TokenCaptureFlags};
+use crate::rewritable_units::{DocumentEnd, Token, TokenCaptureFlags};
 use crate::selectors_vm::{AuxStartTagInfoRequest, ElementData, SelectorMatchingVm, VmError};
 use crate::transform_stream::*;
 use std::cell::RefCell;
@@ -128,6 +128,13 @@ impl TransformController for HtmlRewriteController<'_> {
         self.handlers_dispatcher
             .borrow_mut()
             .handle_token(token, current_element_data)
+            .map_err(RewritingError::ContentHandlerError)
+    }
+
+    fn handle_end(&mut self, document_end: &mut DocumentEnd) -> Result<(), RewritingError> {
+        self.handlers_dispatcher
+            .borrow_mut()
+            .handle_end(document_end)
             .map_err(RewritingError::ContentHandlerError)
     }
 

--- a/src/selectors_vm/mod.rs
+++ b/src/selectors_vm/mod.rs
@@ -530,7 +530,7 @@ mod tests {
     use crate::errors::RewritingError;
     use crate::html::Namespace;
     use crate::memory::MemoryLimiter;
-    use crate::rewritable_units::{Token, TokenCaptureFlags};
+    use crate::rewritable_units::{DocumentEnd, Token, TokenCaptureFlags};
     use crate::transform_stream::{
         StartTagHandlingResult, TransformController, TransformStream, TransformStreamSettings,
     };
@@ -589,6 +589,10 @@ mod tests {
 
             fn handle_end_tag(&mut self, _: LocalName) -> TokenCaptureFlags {
                 TokenCaptureFlags::all()
+            }
+
+            fn handle_end(&mut self, _: &mut DocumentEnd) -> Result<(), RewritingError> {
+                Ok(())
             }
 
             fn handle_token(&mut self, token: &mut Token) -> Result<(), RewritingError> {

--- a/src/transform_stream/dispatcher.rs
+++ b/src/transform_stream/dispatcher.rs
@@ -334,9 +334,7 @@ where
         ns: Namespace,
     ) -> Result<ParserDirective, RewritingError> {
         match self.transform_controller.handle_start_tag(name, ns) {
-            Ok(flags) => {
-                Ok(self.apply_capture_flags_from_hint_and_get_next_parser_directive(flags))
-            }
+            Ok(flags) => Ok(self.apply_capture_flags_from_hint_and_get_next_parser_directive(flags)),
             Err(DispatcherError::InfoRequest(aux_info_req)) => {
                 self.got_flags_from_hint = false;
                 self.pending_element_aux_info_req = Some(aux_info_req);

--- a/src/transform_stream/dispatcher.rs
+++ b/src/transform_stream/dispatcher.rs
@@ -6,7 +6,7 @@ use crate::parser::{
     TagLexeme, TagTokenOutline,
 };
 use crate::rewritable_units::{
-    Serialize, ToToken, Token, TokenCaptureFlags, TokenCapturer, TokenCapturerEvent,
+    DocumentEnd, Serialize, ToToken, Token, TokenCaptureFlags, TokenCapturer, TokenCapturerEvent,
 };
 use crate::rewriter::RewritingError;
 use encoding_rs::Encoding;
@@ -35,6 +35,7 @@ pub trait TransformController: Sized {
     fn handle_start_tag(&mut self, name: LocalName, ns: Namespace) -> StartTagHandlingResult<Self>;
     fn handle_end_tag(&mut self, name: LocalName) -> TokenCaptureFlags;
     fn handle_token(&mut self, token: &mut Token) -> Result<(), RewritingError>;
+    fn handle_end(&mut self, document_end: &mut DocumentEnd) -> Result<(), RewritingError>;
     fn should_emit_content(&self) -> bool;
 }
 
@@ -71,6 +72,7 @@ where
     got_flags_from_hint: bool,
     pending_element_aux_info_req: Option<AuxStartTagInfoRequest<C>>,
     emission_enabled: bool,
+    encoding: &'static Encoding,
 }
 
 impl<C, O> Dispatcher<C, O>
@@ -89,6 +91,7 @@ where
             got_flags_from_hint: false,
             pending_element_aux_info_req: None,
             emission_enabled: true,
+            encoding,
         }
     }
 
@@ -102,11 +105,17 @@ where
         self.remaining_content_start = 0;
     }
 
-    pub fn finish(&mut self, input: &[u8]) {
+    pub fn finish(&mut self, input: &[u8]) -> Result<(), RewritingError> {
         self.flush_remaining_input(input, input.len());
+
+        let mut document_end = DocumentEnd::new(&mut self.output_sink, self.encoding);
+
+        self.transform_controller.handle_end(&mut document_end)?;
 
         // NOTE: output the finalizing chunk.
         self.output_sink.handle_chunk(&[]);
+
+        Ok(())
     }
 
     fn try_produce_token_from_lexeme<'i, T>(

--- a/src/transform_stream/mod.rs
+++ b/src/transform_stream/mod.rs
@@ -135,9 +135,7 @@ where
         trace!(@chunk chunk);
 
         self.parser.parse(chunk, true)?;
-        self.dispatcher.borrow_mut().finish(chunk);
-
-        Ok(())
+        self.dispatcher.borrow_mut().finish(chunk)
     }
 
     #[cfg(feature = "integration_test")]

--- a/tests/fixtures/token_capturing.rs
+++ b/tests/fixtures/token_capturing.rs
@@ -7,7 +7,7 @@ use lol_html::{
     TransformStream, Namespace, TransformStreamSettings, MemoryLimiter
 };
 use lol_html::errors::RewritingError;
-use lol_html::html_content::TextType;
+use lol_html::html_content::{DocumentEnd, TextType};
 use lol_html::test_utils::Output;
 
 macro_rules! expect_eql {
@@ -73,6 +73,10 @@ impl TransformController for TestTransformController<'_> {
     fn handle_token(&mut self, token: &mut Token) -> Result<(), RewritingError> {
         (self.token_handler)(token);
 
+        Ok(())
+    }
+
+    fn handle_end(&mut self, _: &mut DocumentEnd) -> Result<(), RewritingError> {
         Ok(())
     }
 

--- a/tools/parser_trace/src/main.rs
+++ b/tools/parser_trace/src/main.rs
@@ -80,6 +80,10 @@ impl TransformController for TraceTransformController {
         Ok(())
     }
 
+    fn handle_end(&mut self, _: &mut DocumentEnd) -> Result<(), RewritingError> {
+        Ok(())
+    }
+
     fn should_emit_content(&self) -> bool {
         true
     }


### PR DESCRIPTION
This should enable users to add a handler that is called after the rewriter finishes.