### PR TITLE
Use quotes to prevent word splitting.

### DIFF
--- a/scripts/precommit.sh
+++ b/scripts/precommit.sh
@@ -6,4 +6,4 @@ set -e
 (cd c-api && cargo fmt --all)
 (cd c-api/tests && cargo fmt --all)
 (cd fuzz && cargo fmt --all)
-cargo fmt --all && git add $(git status --porcelain=v2 | awk 'BEGIN {ORS=" "}; $2 == "MM" {print $9}')
+cargo fmt --all && git add "$(git status --porcelain=v2 | awk 'BEGIN {ORS=" "}; $2 == "MM" {print $9}')"


### PR DESCRIPTION
Checked with ShellCheck.
https://www.shellcheck.net/

https://github.com/koalaman/shellcheck/wiki/SC2046