### PR TITLE
Take `self` in HtmlRewriter::end

### DIFF
--- a/c-api/include/lol_html.h
+++ b/c-api/include/lol_html.h
@@ -261,8 +261,8 @@ int lol_html_rewriter_write(
 // Returns 0 in case of success and -1 otherwise. The actual error message
 // can be obtained using `lol_html_take_last_error` function.
 //
-// WARNING: if this function errors the rewriter gets into the unrecovarable state,
-// so any further attempts to use the rewriter will cause a thread panic.
+// WARNING: after calling this function, further attempts to use the rewriter
+// (other than `lol_html_rewriter_free`) will cause a thread panic.
 int lol_html_rewriter_end(lol_html_rewriter_t *rewriter);
 
 // Frees the memory held by the rewriter.

--- a/c-api/src/rewriter.rs
+++ b/c-api/src/rewriter.rs
@@ -10,6 +10,10 @@ pub struct ExternOutputSink {
     user_data: *mut c_void,
 }
 
+/// This is a wrapper around `lol_html::HtmlRewriter` which allows
+/// use after the rewriter itself is dropped.
+pub struct HtmlRewriter(Option<lol_html::HtmlRewriter<'static, ExternOutputSink>>);
+
 impl ExternOutputSink {
     #[inline]
     fn new(
@@ -39,7 +43,7 @@ pub extern "C" fn lol_html_rewriter_build(
     output_sink: unsafe extern "C" fn(*const c_char, size_t, *mut c_void),
     output_sink_user_data: *mut c_void,
     strict: bool,
-) -> *mut HtmlRewriter<'static, ExternOutputSink> {
+) -> *mut HtmlRewriter {
     use std::convert::TryInto;
 
     let builder = to_ref!(builder);
@@ -57,19 +61,22 @@ pub extern "C" fn lol_html_rewriter_build(
     };
 
     let output_sink = ExternOutputSink::new(output_sink, output_sink_user_data);
-    let rewriter = HtmlRewriter::new(settings, output_sink);
+    let rewriter = lol_html::HtmlRewriter::new(settings, output_sink);
 
-    to_ptr_mut(rewriter)
+    to_ptr_mut(HtmlRewriter(Some(rewriter)))
 }
 
 #[no_mangle]
 pub extern "C" fn lol_html_rewriter_write(
-    rewriter: *mut HtmlRewriter<'static, ExternOutputSink>,
+    rewriter: *mut HtmlRewriter,
     chunk: *const c_char,
     chunk_len: size_t,
 ) -> c_int {
     let chunk = to_bytes!(chunk, chunk_len);
-    let rewriter = to_ref_mut!(rewriter);
+    let rewriter = to_ref_mut!(rewriter)
+        .0
+        .as_mut()
+        .expect("cannot call `lol_html_rewriter_write` after calling `end()`");
 
     unwrap_or_ret_err_code! { rewriter.write(chunk) };
 
@@ -77,10 +84,11 @@ pub extern "C" fn lol_html_rewriter_write(
 }
 
 #[no_mangle]
-pub extern "C" fn lol_html_rewriter_end(
-    rewriter: *mut HtmlRewriter<'static, ExternOutputSink>,
-) -> c_int {
-    let rewriter = to_ref_mut!(rewriter);
+pub extern "C" fn lol_html_rewriter_end(rewriter: *mut HtmlRewriter) -> c_int {
+    let rewriter = to_ref_mut!(rewriter)
+        .0
+        .take() // Using `take()` allows calling `free()` afterwards (it will be a no-op).
+        .expect("cannot call `lol_html_rewriter_end` after calling `end()`");
 
     unwrap_or_ret_err_code! { rewriter.end() };
 
@@ -88,6 +96,10 @@ pub extern "C" fn lol_html_rewriter_end(
 }
 
 #[no_mangle]
-pub extern "C" fn lol_html_rewriter_free(rewriter: *mut HtmlRewriter<'static, ExternOutputSink>) {
-    drop(to_box!(rewriter));
+pub extern "C" fn lol_html_rewriter_free(rewriter: *mut HtmlRewriter) {
+    assert_not_null!(rewriter);
+    // SAFETY: We already know `rewriter` is not NULL.
+    // The caller is required to ensure that `rewriter` is aligned and that `free` has not been called before.
+    // NOTE: if `end()` was called before, it is valid (but not recommended) to call `free()` more than once.
+    unsafe { std::ptr::drop_in_place(rewriter) };
 }

--- a/fuzz/test_case/src/lib.rs
+++ b/fuzz/test_case/src/lib.rs
@@ -89,12 +89,12 @@ pub fn run_rewriter(data: &[u8]) -> () {
 }
 
 pub fn run_c_api_rewriter(data: &[u8]) -> () {
-    run_c_api_rewriter_iter(data, get_random_encoding());
+    run_c_api_rewriter_iter(data, get_random_encoding().name());
 }
 
-fn get_random_encoding() -> &'static str {
+fn get_random_encoding() -> &'static Encoding {
     let random_encoding_index = rand::thread_rng().gen_range(0, ASCII_COMPATIBLE_ENCODINGS.len());
-    return ASCII_COMPATIBLE_ENCODINGS[random_encoding_index].name();
+    return ASCII_COMPATIBLE_ENCODINGS[random_encoding_index];
 }
 
 fn get_random_selector() -> &'static str {
@@ -102,8 +102,10 @@ fn get_random_selector() -> &'static str {
     return SUPPORTED_SELECTORS[random_selector_index];
 }
 
-fn run_rewriter_iter(data: &[u8], selector: &str, encoding: &str) -> () {
-    let mut rewriter = HtmlRewriter::try_new(
+fn run_rewriter_iter(data: &[u8], selector: &str, encoding: &'static Encoding) -> () {
+    use std::convert::TryInto;
+
+    let mut rewriter = HtmlRewriter::new(
         Settings {
             element_content_handlers: vec![
                 element!(selector, |el| {
@@ -176,13 +178,12 @@ fn run_rewriter_iter(data: &[u8], selector: &str, encoding: &str) -> () {
                     Ok(())
                 }),
             ],
-            encoding,
+            encoding: encoding.try_into().unwrap(),
             memory_settings: MemorySettings::default(),
             strict: false,
         },
         |_: &[u8]| {},
-    )
-    .unwrap();
+    );
 
     rewriter.write(data).unwrap();
     rewriter.end().unwrap();


### PR DESCRIPTION
>  IIRC there were some problems with C API because of that. Need to check.

This was the error:
```
error[E0507]: cannot move out of `*rewriter` which is behind a mutable reference
  --> src/rewriter.rs:80:31
   |
80 |     unwrap_or_ret_err_code! { rewriter.end() };
   |                               ^^^^^^^^ move occurs because `*rewriter` has type `lol_html::HtmlRewriter<'_, rewriter::ExternOutputSink>`, which does not implement the `Copy` trait
```

This commit combines `end()` and `free()` into the same function for the
C API. It also removes tests that `end()` panics when call twice, and
that `write()` panics when called after `read()`, because they no longer
compile:

```
error[E0382]: borrow of moved value: `rewriter`
   --> src/rewriter/mod.rs:610:13
    |
607 |             let mut rewriter = create_rewriter(512, |_: &[u8]| {});
    |                 ------------ move occurs because `rewriter` has type `rewriter::HtmlRewriter<'_, [closure@src/rewriter/mod.rs:607:53: 607:66]>`, which does not implement the `Copy` trait
608 |
609 |             rewriter.end().unwrap();
    |                      ----- `rewriter` moved due to this method call
610 |             rewriter.write(b"foo").unwrap();
    |             ^^^^^^^^ value borrowed here after move

error[E0382]: use of moved value: `rewriter`
   --> src/rewriter/mod.rs:619:13
    |
616 |             let mut rewriter = create_rewriter(512, |_: &[u8]| {});
    |                 ------------ move occurs because `rewriter` has type `rewriter::HtmlRewriter<'_, [closure@src/rewriter/mod.rs:616:53: 616:66]>`, which does not implement the `Copy` trait
617 |
618 |             rewriter.end().unwrap();
    |                      ----- `rewriter` moved due to this method call
619 |             rewriter.end().unwrap();
    |             ^^^^^^^^ value used here after move
```

As a small performance benefit, `finished` can be removed, making the
rewriter take up slightly less memory.

Closes https://github.com/cloudflare/lol-html/issues/59. I didn't run the Rust tests because of https://github.com/rustation/pre-commit/issues/2, but the C tests all pass.

This is a breaking change.