### PR TITLE
Allow linking C bindings into Rust

### DIFF
--- a/c-api/Cargo.toml
+++ b/c-api/Cargo.toml
@@ -18,4 +18,4 @@ panic = "abort"
 lto = true
 
 [lib]
-crate-type = ["staticlib", "cdylib"]
+crate-type = ["staticlib", "cdylib", "rlib"]


### PR DESCRIPTION
When you have multiple disparate Rust libraries that you link into a
larger C/C++ executable, you need to create a super crate that links
all dependencies to avoid linkage issues (e.g. so that Cargo & Rust can
see semver incompatabilities & build them correctly among other things).
Add `rlib` to the `crate-type` list for C bindings to allow building
such a "super" crate.

The following links:

* https://github.com/adetaylor/cxx/blob/book/book/src/building.md#linking-the-c-and-rust-together
* https://github.com/dtolnay/cxx/issues/252

have more context.