### PR TITLE
Fix clippy warnings

### DIFF
--- a/src/html/local_name.rs
+++ b/src/html/local_name.rs
@@ -154,7 +154,7 @@ impl PartialEq<LocalName<'_>> for LocalName<'_> {
 
         match (self, other) {
             (Hash(s), Hash(o)) => s == o,
-            (Bytes(s), Bytes(o)) => s.eq_ignore_ascii_case(&o),
+            (Bytes(s), Bytes(o)) => s.eq_ignore_ascii_case(o),
             _ => false,
         }
     }

--- a/src/rewritable_units/tokens/attributes.rs
+++ b/src/rewritable_units/tokens/attributes.rs
@@ -57,10 +57,9 @@ impl<'i> Attribute<'i> {
     ) -> Result<Bytes<'static>, AttributeNameError> {
         if name.is_empty() {
             Err(AttributeNameError::Empty)
-        } else if let Some(ch) = name.chars().find(|&ch| match ch {
-            ' ' | '\n' | '\r' | '\t' | '\x0C' | '/' | '>' | '=' => true,
-            _ => false,
-        }) {
+        } else if let Some(ch) = name.chars().find(|&ch|
+            matches!(ch, ' ' | '\n' | '\r' | '\t' | '\x0C' | '/' | '>' | '=')
+        ) {
             Err(AttributeNameError::ForbiddenCharacter(ch))
         } else {
             // NOTE: if character can't be represented in the given

--- a/src/rewritable_units/tokens/comment.rs
+++ b/src/rewritable_units/tokens/comment.rs
@@ -54,7 +54,7 @@ impl<'i> Comment<'i> {
     /// Sets the text of the comment.
     #[inline]
     pub fn set_text(&mut self, text: &str) -> Result<(), CommentTextError> {
-        if text.find("-->").is_some() {
+        if text.contains("-->") {
             Err(CommentTextError::CommentClosingSequence)
         } else {
             // NOTE: if character can't be represented in the given

--- a/src/selectors_vm/ast.rs
+++ b/src/selectors_vm/ast.rs
@@ -67,7 +67,7 @@ impl AttributeComparisonExpr {
         case_sensitivity: ParsedCaseSensitivity,
         operator: AttrSelectorOperator,
     ) -> Self {
-        Self { name, value, operator, case_sensitivity }
+        Self { name, value, case_sensitivity, operator }
     }
 }
 

--- a/src/selectors_vm/attribute_matcher.rs
+++ b/src/selectors_vm/attribute_matcher.rs
@@ -195,7 +195,7 @@ impl<'i> AttributeMatcher<'i> {
             let mut haystack = &*actual_value;
 
             loop {
-                match first_byte_searcher(&haystack) {
+                match first_byte_searcher(haystack) {
                     Some(pos) => {
                         haystack = &haystack[pos + 1..];
 

--- a/src/selectors_vm/compiler.rs
+++ b/src/selectors_vm/compiler.rs
@@ -54,7 +54,7 @@ impl Compilable for Expr<OnTagNameExpr> {
             OnTagNameExpr::ExplicitAny => self.compile_expr(|_, _| true),
             OnTagNameExpr::Unmatchable => self.compile_expr(|_, _| false),
             OnTagNameExpr::LocalName(local_name) => {
-                match LocalName::from_str_without_replacements(&local_name, encoding)
+                match LocalName::from_str_without_replacements(local_name, encoding)
                     .map(LocalName::into_owned)
                 {
                     Ok(local_name) => {
@@ -444,7 +444,7 @@ mod tests {
         let instr = &program.instructions[program.entry_points.start];
 
         for_each_test_case(
-            &test_cases,
+            test_cases,
             encoding,
             |input, should_match, state, local_name, attr_matcher| {
                 let res = exec_generic_instr!(instr, state, local_name, attr_matcher);
@@ -508,7 +508,7 @@ mod tests {
         // NOTE: encoding of the individual components is tested by other tests,
         // so we use only UTF-8 here.
         for_each_test_case(
-            &test_cases,
+            test_cases,
             UTF_8,
             |input, expected_payload, state, local_name, attr_matcher| {
                 let (matched_payload, _, _) =

--- a/src/selectors_vm/mod.rs
+++ b/src/selectors_vm/mod.rs
@@ -358,7 +358,7 @@ impl<E: ElementData> SelectorMatchingVm<E> {
     ) {
         let state = self.stack.build_state(&ctx.stack_item.local_name);
         if let Some(branch) =
-            self.program.instructions[addr].complete_exec_with_attrs(&state, &attr_matcher)
+            self.program.instructions[addr].complete_exec_with_attrs(&state, attr_matcher)
         {
             ctx.add_execution_branch(branch, match_handler);
         }
@@ -698,7 +698,7 @@ mod tests {
                                         &mut match_handler,
                                     )
                                     .unwrap(),
-                                    VmError::MemoryLimitExceeded(e) => panic!(e),
+                                    VmError::MemoryLimitExceeded(e) => panic!("{}", e),
                                 }
                             } else {
                                 // NOTE: can't use unwrap() or expect() here, because

--- a/src/selectors_vm/parser.rs
+++ b/src/selectors_vm/parser.rs
@@ -96,7 +96,7 @@ impl SelectorsParser {
             | Component::AttributeInNoNamespace { .. } => Ok(()),
 
             Component::Negation(components) => {
-                components.iter().map(Self::validate_component).collect()
+                components.iter().try_for_each(Self::validate_component)
             }
 
             // Unsupported

--- a/src/selectors_vm/program.rs
+++ b/src/selectors_vm/program.rs
@@ -49,7 +49,7 @@ where
         state: &SelectorState,
         local_name: &LocalName,
     ) -> TryExecResult<'i, P> {
-        if self.local_name_exprs.iter().all(|e| e(&*state, &local_name)) {
+        if self.local_name_exprs.iter().all(|e| e(&*state, local_name)) {
             if self.attribute_exprs.is_empty() {
                 TryExecResult::Branch(&self.associated_branch)
             } else {

--- a/src/transform_stream/dispatcher.rs
+++ b/src/transform_stream/dispatcher.rs
@@ -99,7 +99,7 @@ where
         let output = &input[self.remaining_content_start..consumed_byte_count];
 
         if self.emission_enabled && !output.is_empty() {
-            self.output_sink.handle_chunk(&output);
+            self.output_sink.handle_chunk(output);
         }
 
         self.remaining_content_start = 0;

--- a/src/transform_stream/mod.rs
+++ b/src/transform_stream/mod.rs
@@ -112,7 +112,7 @@ where
 
         self.dispatcher
             .borrow_mut()
-            .flush_remaining_input(&chunk, consumed_byte_count);
+            .flush_remaining_input(chunk, consumed_byte_count);
 
         if consumed_byte_count < chunk.len() {
             self.buffer_blocked_bytes(data, consumed_byte_count)?;


### PR DESCRIPTION
- Remove unnecessary references
- Use `matches!` where possible
- Fix warning that `panic!(e)` will be an error in 2021 edition