### PR TITLE
Return TextType::RawText for SVG text chunks

### DIFF
--- a/src/parser/tree_builder_simulator/mod.rs
+++ b/src/parser/tree_builder_simulator/mod.rs
@@ -79,7 +79,7 @@ fn get_text_type_adjustment(tag_name: LocalNameHash) -> TreeBuilderFeedback {
         PlainText.into()
     } else if tag_name == Tag::Script {
         ScriptData.into()
-    } else if tag_is_one_of!(tag_name, [Style, Iframe, Xmp, Noembed, Noframes, Noscript]) {
+    } else if tag_is_one_of!(tag_name, [Style, Svg, Iframe, Xmp, Noembed, Noframes, Noscript]) {
         RawText.into()
     } else {
         TreeBuilderFeedback::None


### PR DESCRIPTION
Currently found `TextChunk.text_type` returns `TextType::Data` for any `svg` text data. I guess it should behave more like `style` tag as svg is clearly doesn't match regular text

Use case: Getting text data from HTML page - currently following code would include all the regular text nodes plus unnecessary SVG content without ability to filter it out
```rust
document_content_handlers: vec![lol_html::doc_text!(|t| {
                if t.text_type() != lol_html::html_content::TextType::Data { 
                    return Ok(());
                }
                buf += t.as_str()
})]
```