### PR TITLE
Add end tag handler for elements

### DIFF
--- a/src/rewritable_units/tokens/end_tag.rs
+++ b/src/rewritable_units/tokens/end_tag.rs
@@ -1,5 +1,6 @@
 use super::{Mutations, Token};
 use crate::base::Bytes;
+use crate::rewritable_units::ContentType;
 use encoding_rs::Encoding;
 use std::fmt::{self, Debug};
 
@@ -33,6 +34,22 @@ impl<'i> EndTag<'i> {
     pub fn set_name(&mut self, name: Bytes<'static>) {
         self.name = name;
         self.raw = None;
+    }
+
+    #[inline]
+    pub fn before(&mut self, content: &str, content_type: ContentType) {
+        self.mutations.before(content, content_type);
+    }
+
+    #[inline]
+    pub fn after(&mut self, content: &str, content_type: ContentType) {
+        self.mutations.after(content, content_type);
+    }
+
+    /// Removes the end tag.
+    #[inline]
+    pub fn remove(&mut self) {
+        self.mutations.remove();
     }
 
     #[inline]

--- a/src/rewritable_units/tokens/text_chunk.rs
+++ b/src/rewritable_units/tokens/text_chunk.rs
@@ -12,11 +12,15 @@ use std::fmt::{self, Debug};
 /// text node can be represented by multiple text chunks. The size of a chunk depends on multiple
 /// parameters, such as decoding buffer size and input chunk size.
 ///
-/// It is up to a user of the rewriter to buffer content of chunks to get whole text node content
-/// where desired. Last chunk in a text node can be determined by calling [`last_in_text_node`]
-/// method of the chunk.
+/// It is up to a user of the rewriter to buffer content of chunks to get the whole text node
+/// content where desired. The last chunk in a text node can be determined by calling
+/// [`last_in_text_node`] method of the chunk.
 ///
-/// Note that the last chunk in a text node can have empty textual content.
+/// Note that in the sequence `"<span>red-<b>or</b>-blue</span>"` the `span` element contains three text
+/// nodes: `"red-"`, `"or"`, and `"-blue"`. Each of these can produce multiple text chunks and each will
+/// produce one text chunk where [`last_in_text_node`] returns `true`. The last chunk in a text
+/// node can have empty textual content. To perform an action once on the text contents of an
+/// element, see [`Element::on_end_tag`][crate::rewritable_units::Element::on_end_tag].
 ///
 /// # Example
 /// ```

--- a/src/rewriter/settings.rs
+++ b/src/rewriter/settings.rs
@@ -5,7 +5,7 @@ use super::AsciiCompatibleEncoding;
 use std::borrow::Cow;
 use std::error::Error;
 
-pub(super) type HandlerResult = Result<(), Box<dyn Error + Send + Sync>>;
+pub(crate) type HandlerResult = Result<(), Box<dyn Error + Send + Sync>>;
 pub type DoctypeHandler<'h> = Box<dyn FnMut(&mut Doctype) -> HandlerResult + 'h>;
 pub type CommentHandler<'h> = Box<dyn FnMut(&mut Comment) -> HandlerResult + 'h>;
 pub type TextHandler<'h> = Box<dyn FnMut(&mut TextChunk) -> HandlerResult + 'h>;


### PR DESCRIPTION
Provide the ability to run a handler for the end tag. Rather then provide a selector for the end tag, this uses the existing selector on the start tag, and adds an `on_end_tag` method to `Element` to provide a handler that gets triggered when the end tag is reached.

This should be adequate to resolve the issues described in #85, #93, and #96. I'll add an example to #93 of that code using this PR.

This PR also updates the `TextChunk` docs to emphasize that `last_in_text_node` can be true multiple times inside an element when there are sub-elements, and point to the new `Element::on_end_tag` method as an alternative.