### PR TITLE
Expose EndTag and EndTagError as they are public API for on_end_tag

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -52,7 +52,8 @@ pub mod errors {
 /// HTML content descriptors that can be produced and modified by a rewriter.
 pub mod html_content {
     pub use super::rewritable_units::{
-        Attribute, Comment, ContentType, Doctype, DocumentEnd, Element, TextChunk, UserData,
+        Attribute, Comment, ContentType, Doctype, DocumentEnd, Element, EndTag, EndTagError,
+        TextChunk, UserData,
     };
 
     pub use super::html::TextType;


### PR DESCRIPTION
PR #97 introduced a new callback called `on_end_tag` which lets one add a callback to be executed when a tag is closed. This callback is invoked with `EndTag` and returns a result with `EndTagError`. As both those types are internal it's not entirely possible to use this API except for relying on type inference.

This adds those types to the public API.