### PR TITLE
Fix lints and formatting

### DIFF
--- a/src/parser/tree_builder_simulator/ambiguity_guard.rs
+++ b/src/parser/tree_builder_simulator/ambiguity_guard.rs
@@ -2,7 +2,7 @@
 //! parsing context having a limited information about the current
 //! state of tree builder. This caused issues in the past where
 //! Cloudflare's security features were used as XSS gadgets
-//! (see https://portswigger.net/blog/when-security-features-collide).
+//! (see <https://portswigger.net/blog/when-security-features-collide>).
 //! Therefore, due to these safety concerns in such cases we prefer
 //! to bail out from tokenization process.
 //!

--- a/src/rewritable_units/tokens/attributes.rs
+++ b/src/rewritable_units/tokens/attributes.rs
@@ -57,9 +57,10 @@ impl<'i> Attribute<'i> {
     ) -> Result<Bytes<'static>, AttributeNameError> {
         if name.is_empty() {
             Err(AttributeNameError::Empty)
-        } else if let Some(ch) = name.chars().find(|&ch|
-            matches!(ch, ' ' | '\n' | '\r' | '\t' | '\x0C' | '/' | '>' | '=')
-        ) {
+        } else if let Some(ch) = name
+            .chars()
+            .find(|&ch| matches!(ch, ' ' | '\n' | '\r' | '\t' | '\x0C' | '/' | '>' | '='))
+        {
             Err(AttributeNameError::ForbiddenCharacter(ch))
         } else {
             // NOTE: if character can't be represented in the given

--- a/src/selectors_vm/parser.rs
+++ b/src/selectors_vm/parser.rs
@@ -198,7 +198,7 @@ impl<'i> Parser<'i> for SelectorsParser {
 /// `E[foo^="bar"]`                | an `E` element whose foo attribute value begins exactly with the string `"bar"`                                             |
 /// `E[foo$="bar"]`                | an `E` element whose foo attribute value ends exactly with the string `"bar"`                                               |
 /// `E[foo*="bar"]`                | an `E` element whose foo attribute value contains the substring `"bar"`                                                     |
-/// <code>E[foo&#124;="en"]</code> | an `E` element whose foo attribute value is a hyphen-separated list of values beginning with `"en"`                         |
+/// <code>E\[foo&#124;="en"\]</code> | an `E` element whose foo attribute value is a hyphen-separated list of values beginning with `"en"`                         |
 /// `E F`                          | an `F` element descendant of an `E` element                                                                                 |
 /// `E > F`                        | an `F` element child of an `E` element                                                                                      |
 ///

--- a/src/selectors_vm/program.rs
+++ b/src/selectors_vm/program.rs
@@ -1,6 +1,6 @@
-use super::SelectorState;
 use super::attribute_matcher::AttributeMatcher;
 use super::compiler::{CompiledAttributeExpr, CompiledLocalNameExpr};
+use super::SelectorState;
 use crate::html::LocalName;
 use hashbrown::HashSet;
 use std::hash::Hash;
@@ -21,7 +21,7 @@ where
 /// The result of trying to execute an instruction without having parsed all attributes
 pub enum TryExecResult<'i, P>
 where
-    P: Hash + Eq
+    P: Hash + Eq,
 {
     /// A successful match, contains the branch to move to
     Branch(&'i ExecutionBranch<P>),
@@ -78,11 +78,9 @@ where
         local_name: &LocalName,
         attr_matcher: &AttributeMatcher,
     ) -> Option<&'i ExecutionBranch<P>> {
-        let is_match =
-            self.local_name_exprs
-                .iter()
-                .all(|e| e(&*state, local_name)) &&
-            self.attribute_exprs
+        let is_match = self.local_name_exprs.iter().all(|e| e(&*state, local_name))
+            && self
+                .attribute_exprs
                 .iter()
                 .all(|e| e(&*state, attr_matcher));
 

--- a/tests/harness/input.rs
+++ b/tests/harness/input.rs
@@ -1,6 +1,6 @@
 use crate::harness::suites::html5lib_tests::Unescape;
-use lol_html::AsciiCompatibleEncoding;
 use encoding_rs::Encoding;
+use lol_html::AsciiCompatibleEncoding;
 use rand::{thread_rng, Rng};
 use serde::de::{self, Deserialize, Deserializer, Visitor};
 use serde_json::error::Error as SerdeError;

--- a/tests/harness/suites/html5lib_tests/feedback_tests/expected_tokens.rs
+++ b/tests/harness/suites/html5lib_tests/feedback_tests/expected_tokens.rs
@@ -1,4 +1,5 @@
 use super::super::TestToken;
+use hashbrown::HashMap;
 use html5ever::rcdom::RcDom;
 use html5ever::tendril::StrTendril;
 use html5ever::tokenizer::{
@@ -6,7 +7,6 @@ use html5ever::tokenizer::{
     TokenizerResult,
 };
 use html5ever::tree_builder::{TreeBuilder, TreeBuilderOpts};
-use hashbrown::HashMap;
 use std::iter::FromIterator;
 use std::string::ToString;
 

--- a/tests/harness/suites/html5lib_tests/feedback_tests/mod.rs
+++ b/tests/harness/suites/html5lib_tests/feedback_tests/mod.rs
@@ -2,8 +2,8 @@ mod expected_tokens;
 
 use super::super::{for_each_test_file, get_test_file_reader};
 use super::{default_initial_states, Bailout, TestCase};
-use serde_json::from_reader;
 use hashbrown::HashMap;
+use serde_json::from_reader;
 use std::fs::File;
 use std::io::{BufRead, BufReader};
 

--- a/tests/harness/suites/html5lib_tests/test_token.rs
+++ b/tests/harness/suites/html5lib_tests/test_token.rs
@@ -1,9 +1,9 @@
 use super::decoder::{decode_attr_value, decode_text, to_null_decoded};
 use super::Unescape;
+use hashbrown::HashMap;
 use lol_html::Token;
 use serde::de::{Deserialize, Deserializer, Error as DeError};
 use serde_json::error::Error;
-use hashbrown::HashMap;
 use std::fmt::{self, Formatter};
 use std::iter::FromIterator;
 
@@ -73,9 +73,7 @@ impl<'de> Deserialize<'de> for TestToken {
 
                                 value
                             }
-                            None => {
-                                return Err(DeError::invalid_length(actual_length, &$error_msg))
-                            }
+                            None => return Err(DeError::invalid_length(actual_length, &$error_msg)),
                         }
                     };
                 }

--- a/tests/harness/suites/selectors_tests.rs
+++ b/tests/harness/suites/selectors_tests.rs
@@ -1,9 +1,9 @@
 use super::{for_each_test_file, get_test_file_reader};
 use crate::harness::Input;
+use hashbrown::HashMap;
 use lol_html::test_utils::ASCII_COMPATIBLE_ENCODINGS;
 use lol_html::Selector;
 use serde_json::{self, from_reader};
-use hashbrown::HashMap;
 use std::io::prelude::*;
 
 fn read_test_file(suite: &'static str, name: &str) -> String {


### PR DESCRIPTION
https://github.com/cloudflare/lol-html/pull/109 mentioned that the codebase wasn't formatted - I did some investigation and turned up that rustfmt 1.43 - 1.50 had some bugs with outlined modules. This runs the formatting script so that CI passes and other PRs don't have to include unnecessary changes.

This also makes a couple drive-by cleanups for new doc lints - I can drop those if you don't think they're useful.