### PR TITLE
Fix memory leaks in `lol_html_rewriter_free`

### DIFF
--- a/c-api/src/rewriter.rs
+++ b/c-api/src/rewriter.rs
@@ -131,9 +131,8 @@ pub extern "C" fn lol_html_rewriter_end(rewriter: *mut HtmlRewriter) -> c_int {
 
 #[no_mangle]
 pub extern "C" fn lol_html_rewriter_free(rewriter: *mut HtmlRewriter) {
-    assert_not_null!(rewriter);
-    // SAFETY: We already know `rewriter` is not NULL.
+    // SAFETY: `to_box` includes a check that `rewriter` is non-null.
     // The caller is required to ensure that `rewriter` is aligned and that `free` has not been called before.
     // NOTE: if `end()` was called before, it is valid (but not recommended) to call `free()` more than once.
-    unsafe { std::ptr::drop_in_place(rewriter) };
+    drop(to_box!(rewriter))
 }

--- a/c-api/tests/src/test_element_api.c
+++ b/c-api/tests/src/test_element_api.c
@@ -715,5 +715,7 @@ void element_api_test() {
 
         test_element_ns_is_html(selector, &user_data);
         test_element_ns_is_svg(selector, &user_data);
+
+        lol_html_selector_free(selector);
     }
 }

--- a/c-api/tests/src/test_memory_limiting.c
+++ b/c-api/tests/src/test_memory_limiting.c
@@ -35,4 +35,5 @@ void test_memory_limiting() {
 
     str_eq(msg, "The memory limit has been exceeded.");
     lol_html_str_free(*msg);
+    lol_html_rewriter_free(rewriter);
 }

--- a/c-api/tests/src/test_memory_limiting.c
+++ b/c-api/tests/src/test_memory_limiting.c
@@ -36,4 +36,5 @@ void test_memory_limiting() {
     str_eq(msg, "The memory limit has been exceeded.");
     lol_html_str_free(*msg);
     lol_html_rewriter_free(rewriter);
+    lol_html_selector_free(selector);
 }

--- a/c-api/tests/src/test_util.c
+++ b/c-api/tests/src/test_util.c
@@ -92,6 +92,7 @@ void expect_stop(lol_html_rewriter_builder_t *builder, const char *html, void *u
     lol_html_str_t *msg = lol_html_take_last_error();
     str_eq(msg, "The rewriter has been stopped.");
     lol_html_str_free(*msg);
+    lol_html_rewriter_free(rewriter);
 }
 
 void check_output(


### PR DESCRIPTION
Fixes https://github.com/cloudflare/lol-html/issues/101. This is likely a regression caused by https://github.com/cloudflare/lol-html/pull/68, which switched to drop_in_place. This also fixes a couple misc leaks in the test suite, which don't have any production impact, but made it harder to find other leaks.

I also discovered while working on this that `take_last_error` leaks memory unconditionally; there's no way to free the error string it returns. I'm not sure the best way to fix this ... hopefully it doesn't come up much in practice? Here are the remaining valgrind errors:

<details>

```
==70588== HEAP SUMMARY:
==70588==     in use at exit: 978 bytes in 40 blocks
==70588==   total heap usage: 932 allocs, 892 frees, 578,214 bytes allocated
==70588== 
==70588== 16 bytes in 1 blocks are definitely lost in loss record 11 of 40
==70588==    at 0x483B7F3: malloc (in /usr/lib/x86_64-linux-gnu/valgrind/vgpreload_memcheck-amd64-linux.so)
==70588==    by 0x489981B: alloc::alloc::alloc (alloc.rs:86)
==70588==    by 0x48998A6: alloc::alloc::Global::alloc_impl (alloc.rs:166)
==70588==    by 0x4899EF9: <alloc::alloc::Global as core::alloc::Allocator>::allocate (alloc.rs:226)
==70588==    by 0x489977C: alloc::alloc::exchange_malloc (alloc.rs:315)
==70588==    by 0x4893156: new<lolhtml::string::Str> (boxed.rs:192)
==70588==    by 0x4893156: lolhtml::to_ptr (lib.rs:10)
==70588==    by 0x48BEB19: lolhtml::string::Str::opt_ptr (string.rs:22)
==70588==    by 0x489D953: lol_html_take_last_error (errors.rs:12)
==70588==    by 0x116031: test_unsupported_selector (test_unsupported_selector.c:14)
==70588==    by 0x111F1F: subtest (picotest.c:96)
==70588==    by 0x111FA6: run_tests (test.c:11)
==70588==    by 0x111A26: ctests::main (main.rs:8)
==70588== 
==70588== 16 bytes in 1 blocks are definitely lost in loss record 12 of 40
==70588==    at 0x483B7F3: malloc (in /usr/lib/x86_64-linux-gnu/valgrind/vgpreload_memcheck-amd64-linux.so)
==70588==    by 0x489981B: alloc::alloc::alloc (alloc.rs:86)
==70588==    by 0x48998A6: alloc::alloc::Global::alloc_impl (alloc.rs:166)
==70588==    by 0x4899EF9: <alloc::alloc::Global as core::alloc::Allocator>::allocate (alloc.rs:226)
==70588==    by 0x489977C: alloc::alloc::exchange_malloc (alloc.rs:315)
==70588==    by 0x4893156: new<lolhtml::string::Str> (boxed.rs:192)
==70588==    by 0x4893156: lolhtml::to_ptr (lib.rs:10)
==70588==    by 0x48BEB19: lolhtml::string::Str::opt_ptr (string.rs:22)
==70588==    by 0x489D953: lol_html_take_last_error (errors.rs:12)
==70588==    by 0x115402: test_non_ascii_encoding (test_non_ascii_encoding.c:29)
==70588==    by 0x111F1F: subtest (picotest.c:96)
==70588==    by 0x111FB9: run_tests (test.c:12)
==70588==    by 0x111A26: ctests::main (main.rs:8)
==70588== 
==70588== 16 bytes in 1 blocks are definitely lost in loss record 13 of 40
==70588==    at 0x483B7F3: malloc (in /usr/lib/x86_64-linux-gnu/valgrind/vgpreload_memcheck-amd64-linux.so)
==70588==    by 0x489981B: alloc::alloc::alloc (alloc.rs:86)
==70588==    by 0x48998A6: alloc::alloc::Global::alloc_impl (alloc.rs:166)
==70588==    by 0x4899EF9: <alloc::alloc::Global as core::alloc::Allocator>::allocate (alloc.rs:226)
==70588==    by 0x489977C: alloc::alloc::exchange_malloc (alloc.rs:315)
==70588==    by 0x4893156: new<lolhtml::string::Str> (boxed.rs:192)
==70588==    by 0x4893156: lolhtml::to_ptr (lib.rs:10)
==70588==    by 0x48BEB19: lolhtml::string::Str::opt_ptr (string.rs:22)
==70588==    by 0x48A62A9: lol_html_doctype_name_get (doctype.rs:5)
==70588==    by 0x112DC6: get_doctype_fields (test_doctype_api.c:24)
==70588==    by 0x48AE6C3: lolhtml::rewriter_builder::ExternDocumentContentHandlers::as_safe_document_content_handlers::{{closure}} (rewriter_builder.rs:44)
==70588==    by 0x4916042: <alloc::boxed::Box<F,A> as core::ops::function::FnMut<Args>>::call_mut (boxed.rs:1698)
==70588==    by 0x4921640: lol_html::rewriter::handlers_dispatcher::ContentHandlersDispatcher::handle_token::{{closure}} (handlers_dispatcher.rs:253)
==70588== 
==70588== 16 bytes in 1 blocks are definitely lost in loss record 14 of 40
==70588==    at 0x483B7F3: malloc (in /usr/lib/x86_64-linux-gnu/valgrind/vgpreload_memcheck-amd64-linux.so)
==70588==    by 0x489981B: alloc::alloc::alloc (alloc.rs:86)
==70588==    by 0x48998A6: alloc::alloc::Global::alloc_impl (alloc.rs:166)
==70588==    by 0x4899EF9: <alloc::alloc::Global as core::alloc::Allocator>::allocate (alloc.rs:226)
==70588==    by 0x489977C: alloc::alloc::exchange_malloc (alloc.rs:315)
==70588==    by 0x4893156: new<lolhtml::string::Str> (boxed.rs:192)
==70588==    by 0x4893156: lolhtml::to_ptr (lib.rs:10)
==70588==    by 0x48BEB19: lolhtml::string::Str::opt_ptr (string.rs:22)
==70588==    by 0x48A6469: lol_html_doctype_system_id_get (doctype.rs:15)
==70588==    by 0x112DE0: get_doctype_fields (test_doctype_api.c:26)
==70588==    by 0x48AE6C3: lolhtml::rewriter_builder::ExternDocumentContentHandlers::as_safe_document_content_handlers::{{closure}} (rewriter_builder.rs:44)
==70588==    by 0x4916042: <alloc::boxed::Box<F,A> as core::ops::function::FnMut<Args>>::call_mut (boxed.rs:1698)
==70588==    by 0x4921640: lol_html::rewriter::handlers_dispatcher::ContentHandlersDispatcher::handle_token::{{closure}} (handlers_dispatcher.rs:253)
==70588== 
==70588== 16 bytes in 1 blocks are definitely lost in loss record 15 of 40
==70588==    at 0x483B7F3: malloc (in /usr/lib/x86_64-linux-gnu/valgrind/vgpreload_memcheck-amd64-linux.so)
==70588==    by 0x489981B: alloc::alloc::alloc (alloc.rs:86)
==70588==    by 0x48998A6: alloc::alloc::Global::alloc_impl (alloc.rs:166)
==70588==    by 0x4899EF9: <alloc::alloc::Global as core::alloc::Allocator>::allocate (alloc.rs:226)
==70588==    by 0x489977C: alloc::alloc::exchange_malloc (alloc.rs:315)
==70588==    by 0x4893156: new<lolhtml::string::Str> (boxed.rs:192)
==70588==    by 0x4893156: lolhtml::to_ptr (lib.rs:10)
==70588==    by 0x48BEB19: lolhtml::string::Str::opt_ptr (string.rs:22)
==70588==    by 0x489D953: lol_html_take_last_error (errors.rs:12)
==70588==    by 0x116444: expect_stop (test_util.c:92)
==70588==    by 0x112D92: test_stop (test_doctype_api.c:140)
==70588==    by 0x112C39: test_doctype_api (test_doctype_api.c:148)
==70588==    by 0x111F1F: subtest (picotest.c:96)
==70588== 
==70588== 16 bytes in 1 blocks are definitely lost in loss record 16 of 40
==70588==    at 0x483B7F3: malloc (in /usr/lib/x86_64-linux-gnu/valgrind/vgpreload_memcheck-amd64-linux.so)
==70588==    by 0x489981B: alloc::alloc::alloc (alloc.rs:86)
==70588==    by 0x48998A6: alloc::alloc::Global::alloc_impl (alloc.rs:166)
==70588==    by 0x4899EF9: <alloc::alloc::Global as core::alloc::Allocator>::allocate (alloc.rs:226)
==70588==    by 0x489977C: alloc::alloc::exchange_malloc (alloc.rs:315)
==70588==    by 0x4893156: new<lolhtml::string::Str> (boxed.rs:192)
==70588==    by 0x4893156: lolhtml::to_ptr (lib.rs:10)
==70588==    by 0x48BEB19: lolhtml::string::Str::opt_ptr (string.rs:22)
==70588==    by 0x489D953: lol_html_take_last_error (errors.rs:12)
==70588==    by 0x116444: expect_stop (test_util.c:92)
==70588==    by 0x112452: test_stop (test_comment_api.c:305)
==70588==    by 0x1120C1: test_comment_api (test_comment_api.c:345)
==70588==    by 0x111F1F: subtest (picotest.c:96)
==70588== 
==70588== 16 bytes in 1 blocks are definitely lost in loss record 17 of 40
==70588==    at 0x483B7F3: malloc (in /usr/lib/x86_64-linux-gnu/valgrind/vgpreload_memcheck-amd64-linux.so)
==70588==    by 0x489981B: alloc::alloc::alloc (alloc.rs:86)
==70588==    by 0x48998A6: alloc::alloc::Global::alloc_impl (alloc.rs:166)
==70588==    by 0x4899EF9: <alloc::alloc::Global as core::alloc::Allocator>::allocate (alloc.rs:226)
==70588==    by 0x489977C: alloc::alloc::exchange_malloc (alloc.rs:315)
==70588==    by 0x4893156: new<lolhtml::string::Str> (boxed.rs:192)
==70588==    by 0x4893156: lolhtml::to_ptr (lib.rs:10)
==70588==    by 0x48BEB19: lolhtml::string::Str::opt_ptr (string.rs:22)
==70588==    by 0x489D953: lol_html_take_last_error (errors.rs:12)
==70588==    by 0x116444: expect_stop (test_util.c:92)
==70588==    by 0x1124E9: test_stop_with_selector (test_comment_api.c:325)
==70588==    by 0x1120CE: test_comment_api (test_comment_api.c:346)
==70588==    by 0x111F1F: subtest (picotest.c:96)
==70588== 
==70588== 16 bytes in 1 blocks are definitely lost in loss record 18 of 40
==70588==    at 0x483B7F3: malloc (in /usr/lib/x86_64-linux-gnu/valgrind/vgpreload_memcheck-amd64-linux.so)
==70588==    by 0x489981B: alloc::alloc::alloc (alloc.rs:86)
==70588==    by 0x48998A6: alloc::alloc::Global::alloc_impl (alloc.rs:166)
==70588==    by 0x4899EF9: <alloc::alloc::Global as core::alloc::Allocator>::allocate (alloc.rs:226)
==70588==    by 0x489977C: alloc::alloc::exchange_malloc (alloc.rs:315)
==70588==    by 0x4893156: new<lolhtml::string::Str> (boxed.rs:192)
==70588==    by 0x4893156: lolhtml::to_ptr (lib.rs:10)
==70588==    by 0x48BEB19: lolhtml::string::Str::opt_ptr (string.rs:22)
==70588==    by 0x489D953: lol_html_take_last_error (errors.rs:12)
==70588==    by 0x116444: expect_stop (test_util.c:92)
==70588==    by 0x115848: test_stop_with_selector (test_text_chunk_api.c:261)
==70588==    by 0x115538: test_text_chunk_api (test_text_chunk_api.c:298)
==70588==    by 0x111F1F: subtest (picotest.c:96)
==70588== 
==70588== 16 bytes in 1 blocks are definitely lost in loss record 19 of 40
==70588==    at 0x483B7F3: malloc (in /usr/lib/x86_64-linux-gnu/valgrind/vgpreload_memcheck-amd64-linux.so)
==70588==    by 0x489981B: alloc::alloc::alloc (alloc.rs:86)
==70588==    by 0x48998A6: alloc::alloc::Global::alloc_impl (alloc.rs:166)
==70588==    by 0x4899EF9: <alloc::alloc::Global as core::alloc::Allocator>::allocate (alloc.rs:226)
==70588==    by 0x489977C: alloc::alloc::exchange_malloc (alloc.rs:315)
==70588==    by 0x4893156: new<lolhtml::string::Str> (boxed.rs:192)
==70588==    by 0x4893156: lolhtml::to_ptr (lib.rs:10)
==70588==    by 0x48BEB19: lolhtml::string::Str::opt_ptr (string.rs:22)
==70588==    by 0x489D953: lol_html_take_last_error (errors.rs:12)
==70588==    by 0x116444: expect_stop (test_util.c:92)
==70588==    by 0x1158B2: test_stop (test_text_chunk_api.c:279)
==70588==    by 0x115541: test_text_chunk_api (test_text_chunk_api.c:299)
==70588==    by 0x111F1F: subtest (picotest.c:96)
==70588== 
==70588== 16 bytes in 1 blocks are definitely lost in loss record 20 of 40
==70588==    at 0x483B7F3: malloc (in /usr/lib/x86_64-linux-gnu/valgrind/vgpreload_memcheck-amd64-linux.so)
==70588==    by 0x489981B: alloc::alloc::alloc (alloc.rs:86)
==70588==    by 0x48998A6: alloc::alloc::Global::alloc_impl (alloc.rs:166)
==70588==    by 0x4899EF9: <alloc::alloc::Global as core::alloc::Allocator>::allocate (alloc.rs:226)
==70588==    by 0x489977C: alloc::alloc::exchange_malloc (alloc.rs:315)
==70588==    by 0x4893156: new<lolhtml::string::Str> (boxed.rs:192)
==70588==    by 0x4893156: lolhtml::to_ptr (lib.rs:10)
==70588==    by 0x48BEB19: lolhtml::string::Str::opt_ptr (string.rs:22)
==70588==    by 0x489D953: lol_html_take_last_error (errors.rs:12)
==70588==    by 0x1140C0: modify_element_tag_name (test_element_api.c:34)
==70588==    by 0x48AE903: lolhtml::rewriter_builder::ExternElementContentHandlers::as_safe_element_content_handlers::{{closure}} (rewriter_builder.rs:44)
==70588==    by 0x49160C2: <alloc::boxed::Box<F,A> as core::ops::function::FnMut<Args>>::call_mut (boxed.rs:1698)
==70588==    by 0x49215ED: lol_html::rewriter::handlers_dispatcher::ContentHandlersDispatcher::handle_start_tag::{{closure}} (handlers_dispatcher.rs:227)
==70588== 
==70588== 16 bytes in 1 blocks are definitely lost in loss record 21 of 40
==70588==    at 0x483B7F3: malloc (in /usr/lib/x86_64-linux-gnu/valgrind/vgpreload_memcheck-amd64-linux.so)
==70588==    by 0x489981B: alloc::alloc::alloc (alloc.rs:86)
==70588==    by 0x48998A6: alloc::alloc::Global::alloc_impl (alloc.rs:166)
==70588==    by 0x4899EF9: <alloc::alloc::Global as core::alloc::Allocator>::allocate (alloc.rs:226)
==70588==    by 0x489977C: alloc::alloc::exchange_malloc (alloc.rs:315)
==70588==    by 0x4893156: new<lolhtml::string::Str> (boxed.rs:192)
==70588==    by 0x4893156: lolhtml::to_ptr (lib.rs:10)
==70588==    by 0x48BEB19: lolhtml::string::Str::opt_ptr (string.rs:22)
==70588==    by 0x48E25CA: lol_html_element_get_attribute (element.rs:86)
==70588==    by 0x1161AD: get_and_free_empty_element_attribute (test_util.c:24)
==70588==    by 0x48AE903: lolhtml::rewriter_builder::ExternElementContentHandlers::as_safe_element_content_handlers::{{closure}} (rewriter_builder.rs:44)
==70588==    by 0x49160C2: <alloc::boxed::Box<F,A> as core::ops::function::FnMut<Args>>::call_mut (boxed.rs:1698)
==70588==    by 0x49215ED: lol_html::rewriter::handlers_dispatcher::ContentHandlersDispatcher::handle_start_tag::{{closure}} (handlers_dispatcher.rs:227)
==70588== 
==70588== 16 bytes in 1 blocks are definitely lost in loss record 22 of 40
==70588==    at 0x483B7F3: malloc (in /usr/lib/x86_64-linux-gnu/valgrind/vgpreload_memcheck-amd64-linux.so)
==70588==    by 0x489981B: alloc::alloc::alloc (alloc.rs:86)
==70588==    by 0x48998A6: alloc::alloc::Global::alloc_impl (alloc.rs:166)
==70588==    by 0x4899EF9: <alloc::alloc::Global as core::alloc::Allocator>::allocate (alloc.rs:226)
==70588==    by 0x489977C: alloc::alloc::exchange_malloc (alloc.rs:315)
==70588==    by 0x4893156: new<lolhtml::string::Str> (boxed.rs:192)
==70588==    by 0x4893156: lolhtml::to_ptr (lib.rs:10)
==70588==    by 0x48BEB19: lolhtml::string::Str::opt_ptr (string.rs:22)
==70588==    by 0x489D953: lol_html_take_last_error (errors.rs:12)
==70588==    by 0x116444: expect_stop (test_util.c:92)
==70588==    by 0x113E31: test_stop (test_element_api.c:615)
==70588==    by 0x113719: element_api_test (test_element_api.c:701)
==70588==    by 0x111F1F: subtest (picotest.c:96)
==70588== 
==70588== 16 bytes in 1 blocks are definitely lost in loss record 23 of 40
==70588==    at 0x483B7F3: malloc (in /usr/lib/x86_64-linux-gnu/valgrind/vgpreload_memcheck-amd64-linux.so)
==70588==    by 0x489981B: alloc::alloc::alloc (alloc.rs:86)
==70588==    by 0x48998A6: alloc::alloc::Global::alloc_impl (alloc.rs:166)
==70588==    by 0x4899EF9: <alloc::alloc::Global as core::alloc::Allocator>::allocate (alloc.rs:226)
==70588==    by 0x489977C: alloc::alloc::exchange_malloc (alloc.rs:315)
==70588==    by 0x4893156: new<lolhtml::string::Str> (boxed.rs:192)
==70588==    by 0x4893156: lolhtml::to_ptr (lib.rs:10)
==70588==    by 0x48BEB19: lolhtml::string::Str::opt_ptr (string.rs:22)
==70588==    by 0x489D953: lol_html_take_last_error (errors.rs:12)
==70588==    by 0x115281: test_memory_limiting (test_memory_limiting.c:34)
==70588==    by 0x111F1F: subtest (picotest.c:96)
==70588==    by 0x11202B: run_tests (test.c:18)
==70588==    by 0x111A26: ctests::main (main.rs:8)
==70588== 
==70588== 18 (16 direct, 2 indirect) bytes in 1 blocks are definitely lost in loss record 26 of 40
==70588==    at 0x483B7F3: malloc (in /usr/lib/x86_64-linux-gnu/valgrind/vgpreload_memcheck-amd64-linux.so)
==70588==    by 0x489981B: alloc::alloc::alloc (alloc.rs:86)
==70588==    by 0x48998A6: alloc::alloc::Global::alloc_impl (alloc.rs:166)
==70588==    by 0x4899EF9: <alloc::alloc::Global as core::alloc::Allocator>::allocate (alloc.rs:226)
==70588==    by 0x489977C: alloc::alloc::exchange_malloc (alloc.rs:315)
==70588==    by 0x4893156: new<lolhtml::string::Str> (boxed.rs:192)
==70588==    by 0x4893156: lolhtml::to_ptr (lib.rs:10)
==70588==    by 0x48BEB19: lolhtml::string::Str::opt_ptr (string.rs:22)
==70588==    by 0x48E25CA: lol_html_element_get_attribute (element.rs:86)
==70588==    by 0x114824: get_and_modify_attributes (test_element_api.c:135)
==70588==    by 0x48AE903: lolhtml::rewriter_builder::ExternElementContentHandlers::as_safe_element_content_handlers::{{closure}} (rewriter_builder.rs:44)
==70588==    by 0x49160C2: <alloc::boxed::Box<F,A> as core::ops::function::FnMut<Args>>::call_mut (boxed.rs:1698)
==70588==    by 0x49215ED: lol_html::rewriter::handlers_dispatcher::ContentHandlersDispatcher::handle_start_tag::{{closure}} (handlers_dispatcher.rs:227)
==70588== 
==70588== LEAK SUMMARY:
==70588==    definitely lost: 224 bytes in 14 blocks
==70588==    indirectly lost: 2 bytes in 1 blocks
==70588==      possibly lost: 0 bytes in 0 blocks
==70588==    still reachable: 752 bytes in 25 blocks
==70588==         suppressed: 0 bytes in 0 blocks
==70588== Reachable blocks (those to which a pointer was found) are not shown.
```

</details>