### PR TITLE
Fix memory leak when freeing `lol_html_str_t`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## Unreleased
+- Change string allocators in the C API to return `lol_html_str_t`, not `lol_html_str_t*`. This was necessary to fix a memory leak in `lol_html_str_free`. (#115)
+
 ## v0.3.0
 - Add unofficial Go bindings to the README (#77)
 - Update dependencies (#73)

--- a/c-api/Cargo.toml
+++ b/c-api/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "lolhtml"
-version = "0.1.0"
-authors = ["Ivan Nikulin <inikulin@cloudflare.com>"]
+version = "0.2.0"
+authors = ["Ivan Nikulin <inikulin@cloudflare.com>", "Joshua Nelson <jnelson@cloudflare.com>"]
 edition = "2018"
 
 [dependencies]

--- a/c-api/include/lol_html.h
+++ b/c-api/include/lol_html.h
@@ -63,12 +63,14 @@ typedef struct {
 //---------------------------------------------------------------------
 
 // Frees the memory held by the library-allocated string.
+//
+// This is valid to call even if `str.data == NULL` (it does nothing, like `free(NULL)`).
 void lol_html_str_free(lol_html_str_t str);
 
 // Returns the last error message and resets last error to NULL.
 //
-// Return NULL if there was no error.
-lol_html_str_t *lol_html_take_last_error();
+// The `data` field will be NULL if there was no error.
+lol_html_str_t lol_html_take_last_error();
 
 // Creates new HTML rewriter builder.
 lol_html_rewriter_builder_t *lol_html_rewriter_builder_new();
@@ -283,18 +285,18 @@ void lol_html_rewriter_free(lol_html_rewriter_t *rewriter);
 
 // Returns doctype's name.
 //
-// Returns NULL if the doctype doesn't have a name.
-lol_html_str_t *lol_html_doctype_name_get(const lol_html_doctype_t *doctype);
+// The `data` field will be NULL if the doctype doesn't have a name.
+lol_html_str_t lol_html_doctype_name_get(const lol_html_doctype_t *doctype);
 
 // Returns doctype's PUBLIC identifier.
 //
-// Returns NULL if the doctype doesn't have a PUBLIC identifier.
-lol_html_str_t *lol_html_doctype_public_id_get(const lol_html_doctype_t *doctype);
+// The `data` field will be NULL if the doctype doesn't have a PUBLIC identifier.
+lol_html_str_t lol_html_doctype_public_id_get(const lol_html_doctype_t *doctype);
 
 // Returns doctype's SYSTEM identifier.
 //
-// Returns NULL if the doctype doesn't have a SYSTEM identifier.
-lol_html_str_t *lol_html_doctype_system_id_get(const lol_html_doctype_t *doctype);
+// The `data` field will be NULL if the doctype doesn't have a SYSTEM identifier.
+lol_html_str_t lol_html_doctype_system_id_get(const lol_html_doctype_t *doctype);
 
 // Attaches custom user data to the doctype.
 //
@@ -517,14 +519,14 @@ lol_html_str_t lol_html_attribute_name_get(const lol_html_attribute_t *attribute
 // Returns the attribute value.
 lol_html_str_t lol_html_attribute_value_get(const lol_html_attribute_t *attribute);
 
-// Returns the attribute value or NULL if attribute with the given name
+// Returns the attribute value. The `data` field will be NULL if an attribute with the given name
 // doesn't exist on the element.
 //
 // Name should be a valid UTF8-string.
 //
 // If the provided name is invalid UTF8-string the function returns NULL as well.
 // Therefore one should always check `lol_html_take_last_error` result after the call.
-lol_html_str_t *lol_html_element_get_attribute(
+lol_html_str_t lol_html_element_get_attribute(
     const lol_html_element_t *element,
     const char *name,
     size_t name_len

--- a/c-api/src/doctype.rs
+++ b/c-api/src/doctype.rs
@@ -1,18 +1,18 @@
 use super::*;
 
 #[no_mangle]
-pub extern "C" fn lol_html_doctype_name_get(doctype: *const Doctype) -> *const Str {
-    Str::opt_ptr(to_ref!(doctype).name())
+pub extern "C" fn lol_html_doctype_name_get(doctype: *const Doctype) -> Str {
+    Str::from_opt(to_ref!(doctype).name())
 }
 
 #[no_mangle]
-pub extern "C" fn lol_html_doctype_public_id_get(doctype: *const Doctype) -> *const Str {
-    Str::opt_ptr(to_ref!(doctype).public_id())
+pub extern "C" fn lol_html_doctype_public_id_get(doctype: *const Doctype) -> Str {
+    Str::from_opt(to_ref!(doctype).public_id())
 }
 
 #[no_mangle]
-pub extern "C" fn lol_html_doctype_system_id_get(doctype: *const Doctype) -> *const Str {
-    Str::opt_ptr(to_ref!(doctype).system_id())
+pub extern "C" fn lol_html_doctype_system_id_get(doctype: *const Doctype) -> Str {
+    Str::from_opt(to_ref!(doctype).system_id())
 }
 
 #[no_mangle]

--- a/c-api/src/element.rs
+++ b/c-api/src/element.rs
@@ -79,11 +79,11 @@ pub extern "C" fn lol_html_element_get_attribute(
     element: *const Element,
     name: *const c_char,
     name_len: size_t,
-) -> *const Str {
+) -> Str {
     let element = to_ref!(element);
-    let name = unwrap_or_ret_null! { to_str!(name, name_len) };
+    let name = unwrap_or_ret!(to_str!(name, name_len), Str::from_opt(None));
 
-    Str::opt_ptr(element.get_attribute(name))
+    Str::from_opt(element.get_attribute(name))
 }
 
 #[no_mangle]

--- a/c-api/src/errors.rs
+++ b/c-api/src/errors.rs
@@ -6,8 +6,8 @@ thread_local! {
 }
 
 #[no_mangle]
-pub extern "C" fn lol_html_take_last_error() -> *const Str {
+pub extern "C" fn lol_html_take_last_error() -> Str {
     let err = LAST_ERROR.with(|e| e.borrow_mut().take());
 
-    Str::opt_ptr(err.map(|e| e.to_string()))
+    Str::from_opt(err.map(|e| e.to_string()))
 }

--- a/c-api/src/lib.rs
+++ b/c-api/src/lib.rs
@@ -6,11 +6,6 @@ use std::{ptr, slice, str};
 use thiserror::Error;
 
 #[inline]
-fn to_ptr<T>(val: T) -> *const T {
-    Box::into_raw(Box::new(val))
-}
-
-#[inline]
 fn to_ptr_mut<T>(val: T) -> *mut T {
     Box::into_raw(Box::new(val))
 }

--- a/c-api/src/string.rs
+++ b/c-api/src/string.rs
@@ -17,16 +17,25 @@ impl Str {
     }
 
     #[inline]
-    pub fn opt_ptr(string: Option<String>) -> *const Self {
+    /// Convert an `Option<String>` to a C-style string.
+    ///
+    /// If `string` is `None`, `data` will be set to `NULL`.
+    pub fn from_opt(string: Option<String>) -> Self {
         match string {
-            Some(string) => to_ptr(Self::new(string)),
-            None => ptr::null(),
+            Some(string) => Self::new(string),
+            None => Self {
+                data: ptr::null(),
+                len: 0,
+            },
         }
     }
 }
 
 impl Drop for Str {
     fn drop(&mut self) {
+        if self.data == ptr::null() {
+            return;
+        }
         let bytes = unsafe { slice::from_raw_parts_mut(self.data as *mut c_char, self.len) };
 
         drop(unsafe { Box::from_raw(bytes) });

--- a/c-api/tests/src/test_comment_api.c
+++ b/c-api/tests/src/test_comment_api.c
@@ -24,7 +24,7 @@ static lol_html_rewriter_directive_t get_set_comment_text(
     note("Get/set text");
     lol_html_str_t text = lol_html_comment_text_get(comment);
 
-    str_eq(&text, "Hey 42");
+    str_eq(text, "Hey 42");
 
     lol_html_str_free(text);
 

--- a/c-api/tests/src/test_doctype_api.c
+++ b/c-api/tests/src/test_doctype_api.c
@@ -21,16 +21,16 @@ static lol_html_rewriter_directive_t get_doctype_fields(
 
     note("Fields");
 
-    lol_html_str_t *name = lol_html_doctype_name_get(doctype);
-    lol_html_str_t *public_id = lol_html_doctype_public_id_get(doctype);
-    lol_html_str_t *system_id = lol_html_doctype_system_id_get(doctype);
+    lol_html_str_t name = lol_html_doctype_name_get(doctype);
+    lol_html_str_t public_id = lol_html_doctype_public_id_get(doctype);
+    lol_html_str_t system_id = lol_html_doctype_system_id_get(doctype);
 
     str_eq(name, "math");
-    ok(public_id == NULL);
+    ok(public_id.data == NULL);
     str_eq(system_id, "http://www.w3.org/Math/DTD/mathml1/mathml.dtd");
 
-    lol_html_str_free(*name);
-    lol_html_str_free(*system_id);
+    lol_html_str_free(name);
+    lol_html_str_free(system_id);
 
     return LOL_HTML_CONTINUE;
 }

--- a/c-api/tests/src/test_element_api.c
+++ b/c-api/tests/src/test_element_api.c
@@ -24,18 +24,18 @@ static lol_html_rewriter_directive_t modify_element_tag_name(
     note("Get tag name");
     lol_html_str_t name = lol_html_element_tag_name_get(element);
 
-    str_eq(&name, "div");
+    str_eq(name, "div");
 
     lol_html_str_free(name);
 
     note("Set invalid tag name");
     ok(lol_html_element_tag_name_set(element, "", 0) == -1);
 
-    lol_html_str_t *msg = lol_html_take_last_error();
+    lol_html_str_t msg = lol_html_take_last_error();
 
     str_eq(msg, "Tag name can't be empty.");
 
-    lol_html_str_free(*msg);
+    lol_html_str_free(msg);
 
     note("Set tag name");
     ok(!lol_html_element_tag_name_set(element, new_name, strlen(new_name)));
@@ -132,7 +132,7 @@ static lol_html_rewriter_directive_t get_and_modify_attributes(
     ok(!lol_html_element_has_attribute(element, attr2, strlen(attr2)));
 
     note("Get attribute");
-    lol_html_str_t *value = lol_html_element_get_attribute(
+    lol_html_str_t value = lol_html_element_get_attribute(
         element,
         attr1,
         strlen(attr1)
@@ -146,7 +146,7 @@ static lol_html_rewriter_directive_t get_and_modify_attributes(
         strlen(attr2)
     );
 
-    ok(value == NULL);
+    ok(value.data == NULL);
 
     note("Set attribute");
     int err = lol_html_element_set_attribute(
@@ -472,8 +472,8 @@ static lol_html_rewriter_directive_t iterate_element_attributes(
     lol_html_str_t name = lol_html_attribute_name_get(attr);
     lol_html_str_t value = lol_html_attribute_value_get(attr);
 
-    str_eq(&name, "foo");
-    str_eq(&value, "42");
+    str_eq(name, "foo");
+    str_eq(value, "42");
 
     lol_html_str_free(name);
     lol_html_str_free(value);
@@ -485,8 +485,8 @@ static lol_html_rewriter_directive_t iterate_element_attributes(
     name = lol_html_attribute_name_get(attr);
     value = lol_html_attribute_value_get(attr);
 
-    str_eq(&name, "bar");
-    str_eq(&value, "1337");
+    str_eq(name, "bar");
+    str_eq(value, "1337");
 
     lol_html_str_free(name);
     lol_html_str_free(value);

--- a/c-api/tests/src/test_memory_limiting.c
+++ b/c-api/tests/src/test_memory_limiting.c
@@ -31,10 +31,10 @@ void test_memory_limiting() {
 
     ok(lol_html_rewriter_write(rewriter, chunk1, strlen(chunk1)) == -1);
 
-    lol_html_str_t *msg = lol_html_take_last_error();
+    lol_html_str_t msg = lol_html_take_last_error();
 
     str_eq(msg, "The memory limit has been exceeded.");
-    lol_html_str_free(*msg);
+    lol_html_str_free(msg);
     lol_html_rewriter_free(rewriter);
     lol_html_selector_free(selector);
 }

--- a/c-api/tests/src/test_non_ascii_encoding.c
+++ b/c-api/tests/src/test_non_ascii_encoding.c
@@ -26,9 +26,9 @@ void test_non_ascii_encoding() {
 
     ok(rewriter == NULL);
 
-    lol_html_str_t *msg = lol_html_take_last_error();
+    lol_html_str_t msg = lol_html_take_last_error();
 
     str_eq(msg, "Expected ASCII-compatible encoding.");
 
-    lol_html_str_free(*msg);
+    lol_html_str_free(msg);
 }

--- a/c-api/tests/src/test_text_chunk_api.c
+++ b/c-api/tests/src/test_text_chunk_api.c
@@ -25,7 +25,7 @@ static lol_html_rewriter_directive_t insert_before_and_after_text_chunk(
 
     if (content.len > 0) {
         note("Content");
-        str_eq(&content, "Hey 42");
+        str_eq(content, "Hey 42");
 
         note("Remove and last in text node flags");
         ok(!lol_html_text_chunk_is_last_in_text_node(chunk));

--- a/c-api/tests/src/test_unsupported_selector.c
+++ b/c-api/tests/src/test_unsupported_selector.c
@@ -11,9 +11,9 @@ void test_unsupported_selector() {
 
     ok(selector == NULL);
 
-    lol_html_str_t *msg = lol_html_take_last_error();
+    lol_html_str_t msg = lol_html_take_last_error();
 
     str_eq(msg, "Unsupported pseudo-class or pseudo-element in selector.");
 
-    lol_html_str_free(*msg);
+    lol_html_str_free(msg);
 }

--- a/c-api/tests/src/test_util.c
+++ b/c-api/tests/src/test_util.c
@@ -21,14 +21,14 @@ lol_html_rewriter_directive_t get_and_free_empty_element_attribute(
     ok(lol_html_element_has_attribute(element, attr1, strlen(attr1)) == 1);
 
     note("Get attribute");
-    lol_html_str_t *value = lol_html_element_get_attribute(
+    lol_html_str_t value = lol_html_element_get_attribute(
         element,
         attr1,
         strlen(attr1)
     );
 
     str_eq(value, "");
-    lol_html_str_free(*value);
+    lol_html_str_free(value);
 
     return LOL_HTML_CONTINUE;
 }
@@ -89,9 +89,9 @@ void expect_stop(lol_html_rewriter_builder_t *builder, const char *html, void *u
     );
 
     ok(lol_html_rewriter_write(rewriter, in, strlen(in)));
-    lol_html_str_t *msg = lol_html_take_last_error();
+    lol_html_str_t msg = lol_html_take_last_error();
     str_eq(msg, "The rewriter has been stopped.");
-    lol_html_str_free(*msg);
+    lol_html_str_free(msg);
     lol_html_rewriter_free(rewriter);
 }
 

--- a/c-api/tests/src/test_util.h
+++ b/c-api/tests/src/test_util.h
@@ -9,9 +9,9 @@
 #define MAX_MEMORY 2048
 
 #define str_eq(actual, expected) { \
-    ok((actual) != NULL); \
-    ok((actual)->len == strlen(expected)); \
-    ok(!memcmp((actual)->data, expected, (actual)->len)); \
+    ok((actual).data != NULL); \
+    ok((actual).len == strlen(expected)); \
+    ok(!memcmp((actual).data, expected, (actual).len)); \
 }
 
 #define c_str_eq(actual, expected) ok(!strcmp(actual, expected))


### PR DESCRIPTION
Previously, `Str` was double-boxed: one box for the Rust `str`, and another box for the C `Str` that
held the length. That meant the API for `lol_html_str_free` was wrong:
it needed to take `lol_html_str_t*` (i.e. a pointer) but took it by value instead.

Rather than changing the `free` interface, this changes all the string allocators to return `Str` by
value, which allows checking the length unconditionally, without having to check for NULL first.
It also removes an unnecessary heap allocation. Interfaces that previously returned `NULL` now return `Str { len: 0, data: null() }` instead.

I found this while working on https://github.com/cloudflare/lol-html/issues/101 and #113 - thanks to @netanelravid for the bug report!

This is a breaking change.