### PR TITLE
Remove trailing semicolon from macro expression

### DIFF
--- a/src/rewriter/settings.rs
+++ b/src/rewriter/settings.rs
@@ -144,7 +144,7 @@ macro_rules! __element_content_handler {
 #[macro_export(local_inner_macros)]
 macro_rules! element {
     ($selector:expr, $handler:expr) => {
-        __element_content_handler!($selector, element, $handler);
+        __element_content_handler!($selector, element, $handler)
     };
 }
 
@@ -177,7 +177,7 @@ macro_rules! element {
 #[macro_export(local_inner_macros)]
 macro_rules! text {
     ($selector:expr, $handler:expr) => {
-        __element_content_handler!($selector, text, $handler);
+        __element_content_handler!($selector, text, $handler)
     };
 }
 
@@ -208,7 +208,7 @@ macro_rules! text {
 #[macro_export(local_inner_macros)]
 macro_rules! comments {
     ($selector:expr, $handler:expr) => {
-        __element_content_handler!($selector, comments, $handler);
+        __element_content_handler!($selector, comments, $handler)
     };
 }
 
@@ -246,7 +246,7 @@ macro_rules! __document_content_handler {
 #[macro_export(local_inner_macros)]
 macro_rules! doctype {
     ($handler:expr) => {
-        __document_content_handler!(doctype, $handler);
+        __document_content_handler!(doctype, $handler)
     };
 }
 
@@ -278,7 +278,7 @@ macro_rules! doctype {
 #[macro_export(local_inner_macros)]
 macro_rules! doc_text {
     ($handler:expr) => {
-        __document_content_handler!(text, $handler);
+        __document_content_handler!(text, $handler)
     };
 }
 
@@ -308,7 +308,7 @@ macro_rules! doc_text {
 #[macro_export(local_inner_macros)]
 macro_rules! doc_comments {
     ($handler:expr) => {
-        __document_content_handler!(comments, $handler);
+        __document_content_handler!(comments, $handler)
     };
 }
 
@@ -347,7 +347,7 @@ macro_rules! doc_comments {
 #[macro_export(local_inner_macros)]
 macro_rules! end {
     ($handler:expr) => {
-        __document_content_handler!(end, $handler);
+        __document_content_handler!(end, $handler)
     };
 }
 


### PR DESCRIPTION
This fixes several future-incompat warnings of the following form when building tests:

```
warning: trailing semicolon in macro used in expression position
   --> src/rewriter/settings.rs:350:51
    |
350 |           __document_content_handler!(end, $handler);
    |                                                     ^
    |
   ::: src/rewritable_units/document_end.rs:76:18
    |
76  |               vec![end!(|end| {
    |  __________________-
77  | |                 handler_called = true;
78  | |                 handler(end);
79  | |
80  | |                 Ok(())
81  | |             })],
    | |______________- in this macro invocation
    |
    = note: `#[warn(semicolon_in_expressions_from_macros)]` on by default
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
    = note: for more information, see issue #79813 <https://github.com/rust-lang/rust/issues/79813>
    = note: this warning originates in the macro `end` (in Nightly builds, run with -Z macro-backtrace for more info)
```