### PR TITLE
Make `Settings` Send + Sync

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -587,6 +587,7 @@ dependencies = [
  "serde",
  "serde_derive",
  "serde_json",
+ "static_assertions",
  "thiserror",
 ]
 
@@ -1237,6 +1238,12 @@ name = "stable_deref_trait"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a8f112729512f8e442d81f95a8a7ddf2b7c6b8a1a6f509a95864142b30cab2d3"
+
+[[package]]
+name = "static_assertions"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
 name = "string_cache"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -59,6 +59,7 @@ rand = "0.8.4"
 rustc-test = "0.3.1"
 itertools = "0.10.1"
 cargo-fuzz = "0.10.2"
+static_assertions = "1.1"
 
 [package.metadata.precommit]
 fmt = "bash ./scripts/precommit.sh"

--- a/src/rewritable_units/document_end.rs
+++ b/src/rewritable_units/document_end.rs
@@ -65,7 +65,7 @@ mod tests {
     fn rewrite_on_end(
         html: &[u8],
         encoding: &'static Encoding,
-        mut handler: impl FnMut(&mut DocumentEnd),
+        mut handler: impl Send + Sync + FnMut(&mut DocumentEnd),
     ) -> String {
         let mut handler_called = false;
 

--- a/src/rewritable_units/element.rs
+++ b/src/rewritable_units/element.rs
@@ -515,7 +515,7 @@ impl<'r, 't> Element<'r, 't> {
     /// ```
     pub fn on_end_tag(
         &mut self,
-        handler: impl FnMut(&mut EndTag) -> HandlerResult + 'static,
+        handler: impl Send + Sync + FnMut(&mut EndTag) -> HandlerResult + 'static,
     ) -> Result<(), EndTagError> {
         if self.can_have_content {
             self.end_tag_handler = Some(Box::new(handler));
@@ -578,7 +578,7 @@ mod tests {
         html: &[u8],
         encoding: &'static Encoding,
         selector: &str,
-        mut handler: impl FnMut(&mut Element),
+        mut handler: impl Send + Sync + FnMut(&mut Element),
     ) -> String {
         let mut handler_called = false;
 

--- a/src/rewritable_units/tokens/comment.rs
+++ b/src/rewritable_units/tokens/comment.rs
@@ -216,7 +216,7 @@ mod tests {
     fn rewrite_comment(
         html: &[u8],
         encoding: &'static Encoding,
-        mut handler: impl FnMut(&mut Comment),
+        mut handler: impl Send + Sync + FnMut(&mut Comment),
     ) -> String {
         let mut handler_called = false;
 

--- a/src/rewritable_units/tokens/doctype.rs
+++ b/src/rewritable_units/tokens/doctype.rs
@@ -118,7 +118,7 @@ mod tests {
     fn rewrite_doctype(
         html: &[u8],
         encoding: &'static Encoding,
-        mut handler: impl FnMut(&mut Doctype),
+        mut handler: impl Send + Sync + FnMut(&mut Doctype),
     ) -> String {
         let mut handler_called = false;
 

--- a/src/rewritable_units/tokens/text_chunk.rs
+++ b/src/rewritable_units/tokens/text_chunk.rs
@@ -284,7 +284,7 @@ mod tests {
     fn rewrite_text_chunk(
         html: &[u8],
         encoding: &'static Encoding,
-        mut handler: impl FnMut(&mut TextChunk),
+        mut handler: impl Send + Sync + FnMut(&mut TextChunk),
     ) -> String {
         let mut handler_called = false;
 

--- a/src/rewriter/settings.rs
+++ b/src/rewriter/settings.rs
@@ -6,12 +6,12 @@ use std::borrow::Cow;
 use std::error::Error;
 
 pub(crate) type HandlerResult = Result<(), Box<dyn Error + Send + Sync>>;
-pub type DoctypeHandler<'h> = Box<dyn FnMut(&mut Doctype) -> HandlerResult + 'h>;
-pub type CommentHandler<'h> = Box<dyn FnMut(&mut Comment) -> HandlerResult + 'h>;
-pub type TextHandler<'h> = Box<dyn FnMut(&mut TextChunk) -> HandlerResult + 'h>;
-pub type ElementHandler<'h> = Box<dyn FnMut(&mut Element) -> HandlerResult + 'h>;
-pub type EndTagHandler<'h> = Box<dyn FnOnce(&mut EndTag) -> HandlerResult + 'h>;
-pub type EndHandler<'h> = Box<dyn FnOnce(&mut DocumentEnd) -> HandlerResult + 'h>;
+pub type DoctypeHandler<'h> = Box<dyn Send + Sync + FnMut(&mut Doctype) -> HandlerResult + 'h>;
+pub type CommentHandler<'h> = Box<dyn Send + Sync + FnMut(&mut Comment) -> HandlerResult + 'h>;
+pub type TextHandler<'h> = Box<dyn Send + Sync + FnMut(&mut TextChunk) -> HandlerResult + 'h>;
+pub type ElementHandler<'h> = Box<dyn Send + Sync + FnMut(&mut Element) -> HandlerResult + 'h>;
+pub type EndTagHandler<'h> = Box<dyn Send + Sync + FnOnce(&mut EndTag) -> HandlerResult + 'h>;
+pub type EndHandler<'h> = Box<dyn Send + Sync + FnOnce(&mut DocumentEnd) -> HandlerResult + 'h>;
 
 /// Specifies element content handlers associated with a selector.
 #[derive(Default)]
@@ -24,7 +24,10 @@ pub struct ElementContentHandlers<'h> {
 impl<'h> ElementContentHandlers<'h> {
     /// Sets a handler for elements matched by a selector.
     #[inline]
-    pub fn element(mut self, handler: impl FnMut(&mut Element) -> HandlerResult + 'h) -> Self {
+    pub fn element(
+        mut self,
+        handler: impl Send + Sync + FnMut(&mut Element) -> HandlerResult + 'h,
+    ) -> Self {
         self.element = Some(Box::new(handler));
 
         self
@@ -32,7 +35,10 @@ impl<'h> ElementContentHandlers<'h> {
 
     /// Sets a handler for HTML comments in the inner content of elements matched by a selector.
     #[inline]
-    pub fn comments(mut self, handler: impl FnMut(&mut Comment) -> HandlerResult + 'h) -> Self {
+    pub fn comments(
+        mut self,
+        handler: impl Send + Sync + FnMut(&mut Comment) -> HandlerResult + 'h,
+    ) -> Self {
         self.comments = Some(Box::new(handler));
 
         self
@@ -40,7 +46,10 @@ impl<'h> ElementContentHandlers<'h> {
 
     /// Sets a handler for text chunks in the inner content of elements matched by a selector.
     #[inline]
-    pub fn text(mut self, handler: impl FnMut(&mut TextChunk) -> HandlerResult + 'h) -> Self {
+    pub fn text(
+        mut self,
+        handler: impl Send + Sync + FnMut(&mut TextChunk) -> HandlerResult + 'h,
+    ) -> Self {
         self.text = Some(Box::new(handler));
 
         self
@@ -75,7 +84,10 @@ impl<'h> DocumentContentHandlers<'h> {
     ///
     /// [document type declaration]: https://developer.mozilla.org/en-US/docs/Glossary/Doctype
     #[inline]
-    pub fn doctype(mut self, handler: impl FnMut(&mut Doctype) -> HandlerResult + 'h) -> Self {
+    pub fn doctype(
+        mut self,
+        handler: impl Send + Sync + FnMut(&mut Doctype) -> HandlerResult + 'h,
+    ) -> Self {
         self.doctype = Some(Box::new(handler));
 
         self
@@ -83,7 +95,10 @@ impl<'h> DocumentContentHandlers<'h> {
 
     /// Sets a handler for all HTML comments present in the input HTML markup.
     #[inline]
-    pub fn comments(mut self, handler: impl FnMut(&mut Comment) -> HandlerResult + 'h) -> Self {
+    pub fn comments(
+        mut self,
+        handler: impl Send + Sync + FnMut(&mut Comment) -> HandlerResult + 'h,
+    ) -> Self {
         self.comments = Some(Box::new(handler));
 
         self
@@ -91,7 +106,10 @@ impl<'h> DocumentContentHandlers<'h> {
 
     /// Sets a handler for all text chunks present in the input HTML markup.
     #[inline]
-    pub fn text(mut self, handler: impl FnMut(&mut TextChunk) -> HandlerResult + 'h) -> Self {
+    pub fn text(
+        mut self,
+        handler: impl Send + Sync + FnMut(&mut TextChunk) -> HandlerResult + 'h,
+    ) -> Self {
         self.text = Some(Box::new(handler));
 
         self
@@ -99,7 +117,10 @@ impl<'h> DocumentContentHandlers<'h> {
 
     /// Sets a handler for the document end, which is called after the last chunk is processed.
     #[inline]
-    pub fn end(mut self, handler: impl FnMut(&mut DocumentEnd) -> HandlerResult + 'h) -> Self {
+    pub fn end(
+        mut self,
+        handler: impl Send + Sync + FnMut(&mut DocumentEnd) -> HandlerResult + 'h,
+    ) -> Self {
         self.end = Some(Box::new(handler));
 
         self

--- a/src/rewriter/settings.rs
+++ b/src/rewriter/settings.rs
@@ -675,3 +675,8 @@ impl Default for RewriteStrSettings<'_, '_> {
         }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    static_assertions::assert_impl_all!(crate::Settings: Send, Sync);
+}


### PR DESCRIPTION
This works by requiring ElementContentHandlers to be Send + Sync. Making `Settings` Send + Sync can be useful if you want to reuse the same settings across multiple rewriters in different threads.

This is a breaking change.

Helps with https://github.com/cloudflare/lol-html/issues/82, but I'd prefer to avoid merging it until I hear back from the author about why they need this.