### PR TITLE
Simplify macros for the state machine DSL

### DIFF
--- a/src/parser/state_machine/mod.rs
+++ b/src/parser/state_machine/mod.rs
@@ -120,7 +120,18 @@ pub trait StateMachineConditions {
 }
 
 pub trait StateMachine: StateMachineActions + StateMachineConditions {
-    define_states!();
+    cdata_section_states_group!();
+    data_states_group!();
+    plaintext_states_group!();
+    rawtext_states_group!();
+    rcdata_states_group!();
+    script_data_states_group!();
+    script_data_escaped_states_group!();
+    script_data_double_escaped_states_group!();
+    tag_states_group!();
+    attributes_states_group!();
+    comment_states_group!();
+    doctype_states_group!();
 
     fn state(&self) -> fn(&mut Self, &[u8]) -> StateResult;
     fn set_state(&mut self, state: fn(&mut Self, &[u8]) -> StateResult);

--- a/src/parser/state_machine/syntax/mod.rs
+++ b/src/parser/state_machine/syntax/mod.rs
@@ -9,20 +9,3 @@ mod comment;
 
 #[macro_use]
 mod doctype;
-
-macro_rules! define_states {
-    () => {
-        cdata_section_states_group!();
-        data_states_group!();
-        plaintext_states_group!();
-        rawtext_states_group!();
-        rcdata_states_group!();
-        script_data_states_group!();
-        script_data_escaped_states_group!();
-        script_data_double_escaped_states_group!();
-        tag_states_group!();
-        attributes_states_group!();
-        comment_states_group!();
-        doctype_states_group!();
-    };
-}


### PR DESCRIPTION
I made this change while trying to debug an error I'd introduced in the DSL, then realized that changing each macro one at a time was going to be a nightmare and opened https://github.com/rust-lang/rust/issues/92180. No strong opinion on whether this should get merged or not.