### PR TITLE
Improve error messages in the C API test suite

### DIFF
--- a/c-api/tests/src/test_util.c
+++ b/c-api/tests/src/test_util.c
@@ -1,4 +1,6 @@
+#include <stdio.h>
 #include <stdlib.h>
+#include <assert.h>
 
 #include "deps/picotest/picotest.h"
 #include "test_util.h"
@@ -107,8 +109,13 @@ void check_output(
         memcpy(*out + *out_len, chunk, chunk_len);
         *out_len += chunk_len;
     } else {
-        ok(*out_len == strlen(expected));
-        ok(!memcmp(*out, expected, *out_len));
+        int same_len = *out_len == strlen(expected);
+        ok(same_len);
+        int same_data = !memcmp(*out, expected, *out_len);
+        ok(same_data);
+        if (!same_len || !same_data) {
+            printf("err: '%s' != '%s'\n", *out, expected);
+        }
     }
 }
 

--- a/c-api/tests/src/test_util.c
+++ b/c-api/tests/src/test_util.c
@@ -120,5 +120,6 @@ void check_output(
 }
 
 void check_user_data(void *user_data, void *user_data_expected, size_t user_data_len) {
+    assert(user_data != NULL);
     ok(!memcmp(user_data, user_data_expected, user_data_len));
 }


### PR DESCRIPTION
- Print a better error message in `check_output` if two strings don't match
- Don't segfault if a NULL pointer is passed to `check_user_data` / `run_rewriter`