### PR TITLE
Add a C API for `on_end_tag`

### DIFF
--- a/c-api/include/lol_html.h
+++ b/c-api/include/lol_html.h
@@ -23,6 +23,7 @@ typedef struct lol_html_HtmlRewriterBuilder lol_html_rewriter_builder_t;
 typedef struct lol_html_HtmlRewriter lol_html_rewriter_t;
 typedef struct lol_html_Doctype lol_html_doctype_t;
 typedef struct lol_html_DocumentEnd lol_html_doc_end_t;
+typedef struct lol_html_EndTag lol_html_end_tag_t;
 typedef struct lol_html_Comment lol_html_comment_t;
 typedef struct lol_html_TextChunk lol_html_text_chunk_t;
 typedef struct lol_html_Element lol_html_element_t;
@@ -107,6 +108,11 @@ typedef lol_html_rewriter_directive_t (*lol_html_element_handler_t)(
 
 typedef lol_html_rewriter_directive_t (*lol_html_doc_end_handler_t)(
     lol_html_doc_end_t *doc_end,
+    void *user_data
+);
+
+typedef lol_html_rewriter_directive_t (*lol_html_end_tag_handler_t)(
+    lol_html_end_tag_t *end_tag,
     void *user_data
 );
 
@@ -670,6 +676,69 @@ void lol_html_element_user_data_set(
 
 // Returns user data attached to the text chunk.
 void *lol_html_element_user_data_get(const lol_html_element_t *element);
+
+// Adds content handlers to the builder for the end tag of the given element.
+//
+// Subsequent calls to the method on the same element replace the previous handler.
+//
+// The handler can optionally have associated user data which will be
+// passed to the handler on each invocation along with the rewritable
+// unit argument.
+//
+// If the handler returns LOL_HTML_STOP directive then rewriting
+// stops immediately and `write()` or `end()` of the rewriter methods
+// return an error code.
+//
+// Returns 0 in case of success and -1 otherwise. The actual error message
+// can be obtained using `lol_html_take_last_error` function.
+//
+// WARNING: Pointers passed to handlers are valid only during the
+// handler execution. So they should never be leaked outside of handlers.
+int lol_html_element_on_end_tag(lol_html_element_t* element, lol_html_end_tag_handler_t end_tag_handler, void* user_data);
+
+// Inserts the content string before the element's end tag either as raw text or as HTML.
+//
+// Content should be a valid UTF8-string.
+//
+// Returns 0 in case of success and -1 otherwise. The actual error message
+// can be obtained using `lol_html_take_last_error` function.
+int lol_html_end_tag_before(
+    lol_html_end_tag_t *end_tag,
+    const char *content,
+    size_t content_len,
+    bool is_html
+);
+
+// Inserts the content string right after the element's end tag as raw text or as HTML.
+//
+// Content should be a valid UTF8-string.
+//
+// Returns 0 in case of success and -1 otherwise. The actual error message
+// can be obtained using `lol_html_take_last_error` function.
+int lol_html_end_tag_after(
+    lol_html_end_tag_t *end_tag,
+    const char *content,
+    size_t content_len,
+    bool is_html
+);
+
+// Removes the end tag.
+void lol_html_end_tag_remove(lol_html_end_tag_t *end_tag);
+
+// Returns the end tag name.
+lol_html_str_t lol_html_end_tag_name_get(const lol_html_end_tag_t *end_tag);
+
+// Sets the tag name of the end tag.
+//
+// Name should be a valid UTF8-string.
+//
+// Returns 0 in case of success and -1 otherwise. The actual error message
+// can be obtained using `lol_html_take_last_error` function.
+int lol_html_end_tag_name_set(
+    lol_html_end_tag_t *end_tag,
+    const char *name,
+    size_t name_len
+);
 
 // Inserts the content at the end of the document, either as raw text or as HTML.
 //

--- a/c-api/src/element.rs
+++ b/c-api/src/element.rs
@@ -227,10 +227,6 @@ pub extern "C" fn lol_html_element_on_end_tag(
     user_data: *mut c_void,
 ) -> c_int {
     let element = to_ref_mut!(element);
-    // TODO: should this pass `user_data`? The problem is it will be using an old version of the
-    // user data set before the rewriter started running ... maybe we should just let the callback
-    // call `user_data_get` if it wants to associate data with this?
-    // let user_data = element.user_data().downcase_ref::<*mut c_void>().unwrap_or(ptr::null_mut());
     let () = unwrap_or_ret_err_code!(element.on_end_tag(move |end_tag| {
         match unsafe { handler(end_tag, user_data) } {
             RewriterDirective::Continue => Ok(()),
@@ -279,6 +275,6 @@ pub extern "C" fn lol_html_end_tag_name_set(
 ) -> c_int {
     let tag = to_ref_mut!(end_tag);
     let name = unwrap_or_ret_err_code! { to_str!(name, len) };
-    tag.set_name_str(name);
+    tag.set_name_str(name.to_string());
     0
 }

--- a/c-api/tests/src/deps/picotest/picotest.c
+++ b/c-api/tests/src/deps/picotest/picotest.c
@@ -26,6 +26,7 @@
 #include <stdio.h>
 #include <string.h>
 #include "picotest.h"
+#include "../../../../include/lol_html.h"
 
 struct test_t {
     int num_tests;
@@ -73,6 +74,16 @@ void _ok(int cond, const char *fmt, ...)
 
     printf("\n");
     fflush(stdout);
+}
+
+void _lol_ok(int cond, const char *file, int line) {
+    cond = !cond; // lol-html returns 0 on success
+    _ok(cond, "%s %d", file, line);
+    if (!cond) {
+        lol_html_str_t err = lol_html_take_last_error();
+        assert(err.data != NULL && err.len != 0);
+        printf("err: last lol_html err: %s", err.data);
+    }
 }
 
 int done_testing(void)

--- a/c-api/tests/src/deps/picotest/picotest.h
+++ b/c-api/tests/src/deps/picotest/picotest.h
@@ -22,13 +22,17 @@
 #ifndef picotest_h
 #define picotest_h
 
+#include <assert.h>
+
 #ifdef __cplusplus
 extern "C" {
 #endif
 
 void note(const char *fmt, ...)  __attribute__((format (printf, 1, 2)));
 void _ok(int cond, const char *fmt, ...) __attribute__((format (printf, 2, 3)));
+void _lol_ok(int cond, const char *file, int line);
 #define ok(cond) _ok(cond, "%s %d", __FILE__, __LINE__)
+#define lol_ok(cond) _lol_ok(cond, __FILE__, __LINE__)
 int done_testing(void);
 void subtest(const char *name, void (*cb)(void));
 

--- a/src/base/bytes.rs
+++ b/src/base/bytes.rs
@@ -20,6 +20,15 @@ impl<'b> Bytes<'b> {
         encoding.encode(string).0.into()
     }
 
+    /// Same as `Bytes::from_str(&string).into_owned()`, but avoids copying in the common case where
+    /// the output and input encodings are the same.
+    pub fn from_string(string: String, encoding: &'static Encoding) -> Bytes<'static> {
+        Bytes(Cow::Owned(match encoding.encode(&string).0 {
+            Cow::Owned(bytes) => bytes,
+            Cow::Borrowed(_) => string.into_bytes(),
+        }))
+    }
+
     #[inline]
     pub fn from_str_without_replacements(
         string: &'b str,

--- a/src/rewritable_units/tokens/end_tag.rs
+++ b/src/rewritable_units/tokens/end_tag.rs
@@ -37,9 +37,8 @@ impl<'i> EndTag<'i> {
     }
 
     #[inline]
-    // FIXME(encoding_rs#77): take an owned value for `name` to avoid an extra copy.
-    pub fn set_name_str(&mut self, name: &str) {
-        self.set_name(Bytes::from_str(name, self.encoding).into_owned())
+    pub fn set_name_str(&mut self, name: String) {
+        self.set_name(Bytes::from_string(name, self.encoding))
     }
 
     #[inline]

--- a/src/rewritable_units/tokens/end_tag.rs
+++ b/src/rewritable_units/tokens/end_tag.rs
@@ -37,6 +37,12 @@ impl<'i> EndTag<'i> {
     }
 
     #[inline]
+    // FIXME(encoding_rs#77): take an owned value for `name` to avoid an extra copy.
+    pub fn set_name_str(&mut self, name: &str) {
+        self.set_name(Bytes::from_str(name, self.encoding).into_owned())
+    }
+
+    #[inline]
     pub fn before(&mut self, content: &str, content_type: ContentType) {
         self.mutations.before(content, content_type);
     }


### PR DESCRIPTION
- Expose `Element::on_end_tag`
- Expose all the methods of `EndTag` (`name`, `set_name`, `before`, `after`, `remove`)
- Add a new `EndTag::set_name_str` function to make sure it uses the proper encoding. Using
    `set_name` would require blindly assuming that the rewriter always used UTF8.
   This API can be slightly more efficient once https://github.com/hsivonen/encoding_rs/pull/77 is merged, but I'm not sure how long it will take, so it might be better to just merge this as-is and make a breaking change eventually.
- Add a test to ensure all the new API works correctly

Fixes https://github.com/cloudflare/lol-html/issues/85