### PR TITLE
Add CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,20 +23,13 @@ jobs:
       - name: Get rust version
         id: rust-version
         run: echo "::set-output name=version::$(rustc --version)"
-      - name: Cache cargo index
+      - name: Cache cargo index and registry
         uses: actions/cache@v1
+        key: immutable # this will always be hit because it's a constant
         with:
-          path: ~/.cargo/registry/index
-          key: index-${{ runner.os }}-${{ github.run_number }}
-          restore-keys: |
-            index-${{ runner.os }}-
+          path: ~/.cargo/registry
       - name: Create lockfile
         run: cargo generate-lockfile
-      - name: Cache cargo registry
-        uses: actions/cache@v1
-        with:
-          path: ~/.cargo/registry/cache
-          key: registry-${{ runner.os }}-${{ steps.rust-version.outputs.version }}-${{ hashFiles('Cargo.lock') }}
       - name: Fetch dependencies
         run: cargo fetch
       - name: Cache target directory

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,58 @@
+name: CI
+
+on:
+  pull_request:
+  push:
+    branches:
+      - master
+
+env:
+  RUSTFLAGS: -Dwarnings
+  RUST_BACKTRACE: 1
+
+jobs:
+  clippy:
+    name: clippy
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          submodules: 'recursive'
+      - name: Install Rust
+        run: rustup update stable && rustup default stable
+      - name: Get rust version
+        id: rust-version
+        run: echo "::set-output name=version::$(rustc --version)"
+      - name: Cache cargo index
+        uses: actions/cache@v1
+        with:
+          path: ~/.cargo/registry/index
+          key: index-${{ runner.os }}-${{ github.run_number }}
+          restore-keys: |
+            index-${{ runner.os }}-
+      - name: Create lockfile
+        run: cargo generate-lockfile
+      - name: Cache cargo registry
+        uses: actions/cache@v1
+        with:
+          path: ~/.cargo/registry/cache
+          key: registry-${{ runner.os }}-${{ steps.rust-version.outputs.version }}-${{ hashFiles('Cargo.lock') }}
+      - name: Fetch dependencies
+        run: cargo fetch
+      - name: Cache target directory
+        uses: actions/cache@v1
+        with:
+          path: target
+          key: clippy-target-${{ runner.os }}-${{ steps.rust-version.outputs.version }}-${{ hashFiles('Cargo.lock') }}
+      - name: Run clippy
+        run: cargo clippy --all --all-targets
+  test:
+    name: Test
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - name: Install Rust (rustup)
+      run: rustup update stable --no-self-update && rustup default stable
+      shell: bash
+    - name: Run tests
+      run: scripts/test.sh

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -490,8 +490,7 @@ dependencies = [
 [[package]]
 name = "html5ever"
 version = "0.25.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aafcf38a1a36118242d29b92e1b08ef84e67e4a5ed06e0a80be20e6a32bfed6b"
+source = "git+https://github.com/servo/html5ever?rev=1b34cf17c6586a2dc1c120bf6a1fd88cf4c86021#1b34cf17c6586a2dc1c120bf6a1fd88cf4c86021"
 dependencies = [
  "log",
  "mac",
@@ -578,6 +577,7 @@ dependencies = [
  "itertools",
  "lazy_static",
  "lazycell",
+ "markup5ever_rcdom",
  "memchr",
  "pre-commit",
  "rand 0.8.4",
@@ -598,9 +598,8 @@ checksum = "c41e0c4fef86961ac6d6f8a82609f55f31b05e4fce149ac5710e439df7619ba4"
 
 [[package]]
 name = "markup5ever"
-version = "0.10.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a24f40fb03852d1cdd84330cddcaf98e9ec08a7b7768e952fad3b4cf048ec8fd"
+version = "0.10.0"
+source = "git+https://github.com/servo/html5ever?rev=1b34cf17c6586a2dc1c120bf6a1fd88cf4c86021#1b34cf17c6586a2dc1c120bf6a1fd88cf4c86021"
 dependencies = [
  "log",
  "phf",
@@ -608,6 +607,17 @@ dependencies = [
  "string_cache",
  "string_cache_codegen",
  "tendril",
+]
+
+[[package]]
+name = "markup5ever_rcdom"
+version = "0.1.0"
+source = "git+https://github.com/servo/html5ever?rev=1b34cf17c6586a2dc1c120bf6a1fd88cf4c86021#1b34cf17c6586a2dc1c120bf6a1fd88cf4c86021"
+dependencies = [
+ "html5ever",
+ "markup5ever",
+ "tendril",
+ "xml5ever",
 ]
 
 [[package]]
@@ -1595,3 +1605,14 @@ name = "winapi-x86_64-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
+
+[[package]]
+name = "xml5ever"
+version = "0.16.1"
+source = "git+https://github.com/servo/html5ever?rev=1b34cf17c6586a2dc1c120bf6a1fd88cf4c86021#1b34cf17c6586a2dc1c120bf6a1fd88cf4c86021"
+dependencies = [
+ "log",
+ "mac",
+ "markup5ever",
+ "time",
+]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -49,7 +49,8 @@ hashbrown = "0.11.2"
 [dev-dependencies]
 criterion = "0.3.0"
 glob = "0.3.0"
-html5ever = "0.25.1"
+html5ever = { version = "0.25.1", git = "https://github.com/servo/html5ever", rev = "1b34cf17c6586a2dc1c120bf6a1fd88cf4c86021" }
+markup5ever_rcdom = { version = "0.1", git = "https://github.com/servo/html5ever", rev = "1b34cf17c6586a2dc1c120bf6a1fd88cf4c86021" }
 hashbrown = { version = "0.11.2", features = ["serde"] }
 serde = "1.0.126"
 serde_derive = "1.0.19"

--- a/fuzz/test_case/src/lib.rs
+++ b/fuzz/test_case/src/lib.rs
@@ -107,6 +107,7 @@ fn run_rewriter_iter(data: &[u8], selector: &str, encoding: &'static Encoding) -
 
     let mut rewriter = HtmlRewriter::new(
         Settings {
+            enable_esi_tags: true,
             element_content_handlers: vec![
                 element!(selector, |el| {
                     el.before(

--- a/scripts/fuzz_c_api_with_libfuzzer.sh
+++ b/scripts/fuzz_c_api_with_libfuzzer.sh
@@ -2,7 +2,9 @@
 
 set -e
 
-cd ./c-api && cargo +nightly build && \
-cd ../fuzz && cargo +nightly build && \
-cd ..  && \
+cd ./c-api && cargo +nightly build
+cd ../fuzz && cargo +nightly build
+cd ..
+# add `liblolhtml.so` to linker path
+export LD_LIBRARY_PATH="$(realpath ${CARGO_TARGET_DIR:-c-api/target}/debug/deps)"
 rustup run nightly cargo-fuzz run --jobs 24 --release fuzz_c_api fuzz/corpus/selector_matching

--- a/scripts/fuzz_with_libfuzzer.sh
+++ b/scripts/fuzz_with_libfuzzer.sh
@@ -1,8 +1,17 @@
 #!/bin/sh
 
-set -e
+set -eu
 
-cd ./fuzz/ && \
-cargo +nightly build && \
-cd .. & \
+cargo +nightly install cargo-fuzz
+(
+	cd ./c-api
+	# ok to use default toolchain here since C ABI is stable
+	cargo build
+)
+# add `liblolhtml.so` to linker path
+export LD_LIBRARY_PATH="$(realpath ${CARGO_TARGET_DIR:-c-api/target}/debug/deps)"
+(
+	cd ./fuzz
+	cargo +nightly build
+)
 rustup run nightly cargo-fuzz run --jobs 24 --release fuzz_rewriter fuzz/corpus/selector_matching

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -3,7 +3,7 @@
 set -e
 
 echo "===  Running library tests... ==="
-cargo clippy --features=integration_test --all-targets
+cargo clippy --features=integration_test --all-targets -- -Dwarnings
 cargo test --features=integration_test "$@"
 
 echo "=== Running C API tests... ==="

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -10,8 +10,8 @@ echo "=== Running C API tests... ==="
 prove -e 'cargo' run ::  --manifest-path=./c-api/tests/Cargo.toml
 
 echo "=== Building fuzzing test case code to ensure that it uses current API... ==="
-(cd fuzz/test_case && cargo build)
+(cd fuzz/test_case && cargo check)
 
 echo "=== Building the tooling test case code to ensure it uses the current API... ==="
-(cd tools/parser_trace/ && cargo build)
-(cd tools/selectors_ast/ && cargo build)
+(cd tools/parser_trace/ && cargo check)
+(cd tools/selectors_ast/ && cargo check)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -134,15 +134,16 @@ pub mod test_utils {
         }
     }
 
-    impl Into<String> for Output {
-        fn into(self) -> String {
+    impl From<Output> for String {
+        fn from(output: Output) -> String {
             assert!(
-                self.finalizing_chunk_received,
+                output.finalizing_chunk_received,
                 "Finalizing chunk for the output hasn't been received."
             );
 
-            self.encoding
-                .decode_without_bom_handling(&self.bytes)
+            output
+                .encoding
+                .decode_without_bom_handling(&output.bytes)
                 .0
                 .into_owned()
         }

--- a/tests/harness/input.rs
+++ b/tests/harness/input.rs
@@ -63,7 +63,7 @@ impl Input {
                 Ok(val) => val.parse().unwrap(),
                 Err(_) => {
                     if len > 1 {
-                        thread_rng().gen_range(1, len)
+                        thread_rng().gen_range(1..len)
                     } else {
                         len
                     }

--- a/tests/harness/suites/html5lib_tests/feedback_tests/expected_tokens.rs
+++ b/tests/harness/suites/html5lib_tests/feedback_tests/expected_tokens.rs
@@ -1,12 +1,12 @@
 use super::super::TestToken;
 use hashbrown::HashMap;
-use html5ever::rcdom::RcDom;
 use html5ever::tendril::StrTendril;
 use html5ever::tokenizer::{
     BufferQueue, TagKind, Token, TokenSink, TokenSinkResult, Tokenizer, TokenizerOpts,
     TokenizerResult,
 };
 use html5ever::tree_builder::{TreeBuilder, TreeBuilderOpts};
+use markup5ever_rcdom::RcDom;
 use std::iter::FromIterator;
 use std::string::ToString;
 

--- a/tests/harness/suites/html5lib_tests/test_token.rs
+++ b/tests/harness/suites/html5lib_tests/test_token.rs
@@ -180,7 +180,7 @@ impl TestTokenList {
                     }
                 } else {
                     self.0.push(TestToken::Text(if t.last_in_text_node() {
-                        decode_text(&text, t.text_type())
+                        decode_text(text, t.text_type())
                     } else {
                         text.into()
                     }));
@@ -216,8 +216,8 @@ impl TestTokenList {
     }
 }
 
-impl Into<Vec<TestToken>> for TestTokenList {
-    fn into(self) -> Vec<TestToken> {
-        self.0
+impl From<TestTokenList> for Vec<TestToken> {
+    fn from(list: TestTokenList) -> Vec<TestToken> {
+        list.0
     }
 }


### PR DESCRIPTION
- Fix integration tests
- Fix most of the fuzzer scripts. I couldn't get AFL or honggfuzz working, and given that there are so many others I didn't bother working on it too long for now.
- Fix and deny clippy lints
- Test `cargo fmt`, `cargo clippy`, unit tests, integration tests, C API tests, and that fuzz crates build. In the future I'd like to also check that `Cargo.lock` doesn't change compared to the checked-in version, but I'm waiting to hear feedback on https://github.com/cloudflare/lol-html/pull/114 first.