### PR TITLE
Take a `FnOnce` handler for end tags, not `FnMut`

### DIFF
--- a/src/rewritable_units/element.rs
+++ b/src/rewritable_units/element.rs
@@ -515,7 +515,7 @@ impl<'r, 't> Element<'r, 't> {
     /// ```
     pub fn on_end_tag(
         &mut self,
-        handler: impl FnMut(&mut EndTag) -> HandlerResult + 'static,
+        handler: impl FnOnce(&mut EndTag) -> HandlerResult + 'static,
     ) -> Result<(), EndTagError> {
         if self.can_have_content {
             self.end_tag_handler = Some(Box::new(handler));


### PR DESCRIPTION
lol-html already runs the handler at most once; this guarantees that won't change.

cc @harrishancock - this would make some optimizations for the workers runtime you mentioned possible.