### PR TITLE
Add ability to remove doctype

### DIFF
--- a/c-api/include/lol_html.h
+++ b/c-api/include/lol_html.h
@@ -317,6 +317,12 @@ void lol_html_doctype_user_data_set(
 // Returns user data attached to the doctype.
 void *lol_html_doctype_user_data_get(const lol_html_doctype_t *doctype);
 
+// Removes the doctype.
+void lol_html_doctype_remove(lol_html_doctype_t *doctype);
+
+// Returns `true` if the doctype has been removed.
+bool lol_html_doctype_is_removed(const lol_html_doctype_t *doctype);
+
 // Comment
 //---------------------------------------------------------------------
 

--- a/c-api/src/doctype.rs
+++ b/c-api/src/doctype.rs
@@ -24,3 +24,13 @@ pub extern "C" fn lol_html_doctype_user_data_set(doctype: *mut Doctype, user_dat
 pub extern "C" fn lol_html_doctype_user_data_get(doctype: *const Doctype) -> *mut c_void {
     get_user_data!(doctype)
 }
+
+#[no_mangle]
+pub extern "C" fn lol_html_doctype_remove(doctype: *mut Doctype) {
+    to_ref_mut!(doctype).remove();
+}
+
+#[no_mangle]
+pub extern "C" fn lol_html_doctype_is_removed(doctype: *const Doctype) -> bool {
+    to_ref!(doctype).removed()
+}

--- a/c-api/tests/src/test_doctype_api.c
+++ b/c-api/tests/src/test_doctype_api.c
@@ -112,7 +112,7 @@ static void test_get_user_data(void *user_data) {
 //-------------------------------------------------------------------------
 EXPECT_OUTPUT(
     remove_doctype_output_sink,
-    "<!DOCTYPE><html></html>",
+    "<html></html>",
     &EXPECTED_USER_DATA,
     sizeof(EXPECTED_USER_DATA)
 );

--- a/c-api/tests/src/test_doctype_api.c
+++ b/c-api/tests/src/test_doctype_api.c
@@ -110,6 +110,48 @@ static void test_get_user_data(void *user_data) {
 }
 
 //-------------------------------------------------------------------------
+EXPECT_OUTPUT(
+    remove_doctype_output_sink,
+    "<!DOCTYPE><html></html>",
+    &EXPECTED_USER_DATA,
+    sizeof(EXPECTED_USER_DATA)
+);
+
+static lol_html_rewriter_directive_t remove_doctype(
+    lol_html_doctype_t *doctype,
+    void *user_data
+) {
+    UNUSED(user_data);
+
+    note("Removed flag");
+    ok(!lol_html_doctype_is_removed(doctype));
+
+    note("Remove");
+    lol_html_doctype_remove(doctype);
+    ok(lol_html_doctype_is_removed(doctype));
+
+    return LOL_HTML_CONTINUE;
+}
+
+static void test_remove_doctype(void *user_data) {
+    lol_html_rewriter_builder_t *builder = lol_html_rewriter_builder_new();
+
+     lol_html_rewriter_builder_add_document_content_handlers(
+        builder,
+        &remove_doctype,
+        NULL,
+        NULL,
+        NULL,
+        NULL,
+        NULL,
+        NULL,
+        NULL
+    );
+
+    run_rewriter(builder, "<!DOCTYPE><html></html>", remove_doctype_output_sink, user_data);
+}
+
+//-------------------------------------------------------------------------
 static lol_html_rewriter_directive_t stop_rewriting(
     lol_html_doctype_t *doctype,
     void *user_data
@@ -145,5 +187,6 @@ void test_doctype_api() {
 
     test_get_doctype_fields(&user_data);
     test_get_user_data(&user_data);
+    test_remove_doctype(&user_data);
     test_stop(&user_data);
 }

--- a/src/rewritable_units/tokens/capturer/to_token.rs
+++ b/src/rewritable_units/tokens/capturer/to_token.rs
@@ -90,6 +90,7 @@ impl ToToken for NonTagContentLexeme<'_> {
                 self.opt_part(public_id),
                 self.opt_part(system_id),
                 force_quirks,
+                false, // removed
                 self.raw(),
                 encoding,
             )

--- a/src/rewritable_units/tokens/doctype.rs
+++ b/src/rewritable_units/tokens/doctype.rs
@@ -126,9 +126,9 @@ mod tests {
             html,
             encoding,
             vec![],
-            vec![doctype!(|c| {
+            vec![doctype!(|d| {
                 handler_called = true;
-                handler(c);
+                handler(d);
                 Ok(())
             })],
         );


### PR DESCRIPTION
I needed this feature for a project I'm working on (a Ruby wrapper to this crate--I'll send a PR to update the README when it's done 😄 ).

Note that while I could've added `Mutations` to the `struct` like many of the other rewriteable tokens, this didn't seem appropriate for a couple of reasons:

* None of the other functions (like `before` or `after`) are necessary here
* `doctype` has its own `to_bytes` serialization, whereas the others use `impl_serialize!`

Closes https://github.com/cloudflare/lol-html/issues/88.