### PR TITLE
Drop outdated pre-commit dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -55,10 +55,7 @@ hashbrown = { version = "0.12", features = ["serde"] }
 serde = "1.0.126"
 serde_derive = "1.0.19"
 serde_json = "1.0.65"
-pre-commit = "0.5.2"
 rand = "0.8.4"
 rustc-test = "0.3.1"
 itertools = "0.10.1"
 
-[package.metadata.precommit]
-fmt = "bash ./scripts/precommit.sh"

--- a/scripts/precommit.sh
+++ b/scripts/precommit.sh
@@ -1,9 +1,0 @@
-#!/bin/sh
-
-set -e
-
-(cd js-api && cargo fmt --all)
-(cd c-api && cargo fmt --all)
-(cd c-api/tests && cargo fmt --all)
-(cd fuzz && cargo fmt --all)
-cargo fmt --all && git add $(git status --porcelain=v2 | awk 'BEGIN {ORS=" "}; $2 == "MM" {print $9}')


### PR DESCRIPTION
The `pre-commit` crate is unmaintained, uses prehistoric `rustc-serialize` that is even more dead, makes incorrect assumptions about Cargo workspaces. Plus modification of .git dir and sneaky modifications of commits are IMHO hacky and invasive.
