### PR TITLE
Fix clippy lints

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -450,7 +450,6 @@ dependencies = [
  "lazycell",
  "markup5ever_rcdom",
  "memchr",
- "pre-commit",
  "rand 0.8.5",
  "rustc-test",
  "safemem",
@@ -684,16 +683,6 @@ name = "ppv-lite86"
 version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eb9f9e6e233e5c4a35559a617bf40a4ec447db2e84c20b55a6f83167b7e57872"
-
-[[package]]
-name = "pre-commit"
-version = "0.5.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d0f2b9887f84ec91cd86f71c193b883209d744bc8c2a3363c6b1df88efa5af8f"
-dependencies = [
- "rustc-serialize",
- "toml",
-]
 
 [[package]]
 name = "precomputed-hash"
@@ -1144,15 +1133,6 @@ checksum = "be4d6b5f19ff7664e8c98d03e2139cb510db9b0a60b55f8e8709b689d939b6bc"
 dependencies = [
  "serde",
  "serde_json",
-]
-
-[[package]]
-name = "toml"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "736b60249cb25337bc196faa43ee12c705e426f3d55c214d73a4e7be06f92cb4"
-dependencies = [
- "rustc-serialize",
 ]
 
 [[package]]

--- a/src/base/bytes.rs
+++ b/src/base/bytes.rs
@@ -174,6 +174,6 @@ impl Deref for Bytes<'_> {
     type Target = [u8];
 
     fn deref(&self) -> &[u8] {
-        &*self.0
+        &self.0
     }
 }

--- a/src/html/text_type.rs
+++ b/src/html/text_type.rs
@@ -17,7 +17,7 @@ use cfg_if::cfg_if;
 ///
 /// [HTML entities]: https://developer.mozilla.org/en-US/docs/Glossary/Entity
 /// [HTML parsing specification]: https://html.spec.whatwg.org/multipage/parsing.html
-#[derive(Copy, Clone, PartialEq, Debug)]
+#[derive(Copy, Clone, Eq, PartialEq, Debug)]
 pub enum TextType {
     /// Text inside a `<plaintext>` element.
     PlainText,

--- a/src/memory/limiter.rs
+++ b/src/memory/limiter.rs
@@ -8,7 +8,7 @@ pub type SharedMemoryLimiter = Rc<RefCell<MemoryLimiter>>;
 /// [`MemorySettings`].
 ///
 /// [`MemorySettings`]: ../struct.MemorySettings.html
-#[derive(Error, Debug, PartialEq, Copy, Clone)]
+#[derive(Error, Debug, Eq, PartialEq, Copy, Clone)]
 #[error("The memory limit has been exceeded.")]
 pub struct MemoryLimitExceededError;
 

--- a/src/parser/tree_builder_simulator/ambiguity_guard.rs
+++ b/src/parser/tree_builder_simulator/ambiguity_guard.rs
@@ -66,7 +66,7 @@ use thiserror::Error;
 /// correct parsing context.
 ///
 /// [`strict`]: ../struct.Settings.html#structfield.strict
-#[derive(Error, Debug, PartialEq)]
+#[derive(Error, Debug, Eq, PartialEq)]
 pub struct ParsingAmbiguityError {
     on_tag_name: String,
 }

--- a/src/parser/tree_builder_simulator/mod.rs
+++ b/src/parser/tree_builder_simulator/mod.rs
@@ -27,6 +27,7 @@ const DEFAULT_NS_STACK_CAPACITY: usize = 256;
 pub enum TreeBuilderFeedback {
     SwitchTextType(TextType),
     SetAllowCdata(bool),
+    #[allow(clippy::type_complexity)]
     RequestLexeme(Box<dyn FnMut(&mut TreeBuilderSimulator, &TagLexeme) -> TreeBuilderFeedback>),
     None,
 }

--- a/src/rewritable_units/element.rs
+++ b/src/rewritable_units/element.rs
@@ -7,7 +7,7 @@ use std::fmt::{self, Debug};
 use thiserror::Error;
 
 /// An error that occurs when invalid value is provided for the tag name.
-#[derive(Error, Debug, PartialEq, Copy, Clone)]
+#[derive(Error, Debug, Eq, PartialEq, Copy, Clone)]
 pub enum TagNameError {
     /// The provided value is empty.
     #[error("Tag name can't be empty.")]
@@ -31,7 +31,7 @@ pub enum TagNameError {
 }
 
 /// An error that occurs when invalid value is provided for the tag name.
-#[derive(Error, Debug, PartialEq, Copy, Clone)]
+#[derive(Error, Debug, Eq, PartialEq, Copy, Clone)]
 pub enum EndTagError {
     /// The tag has no end tag.
     #[error("No end tag.")]

--- a/src/rewritable_units/tokens/attributes.rs
+++ b/src/rewritable_units/tokens/attributes.rs
@@ -8,7 +8,7 @@ use std::ops::Deref;
 use thiserror::Error;
 
 /// An error that occurs when invalid value is provided for the attribute name.
-#[derive(Error, Debug, PartialEq, Copy, Clone)]
+#[derive(Error, Debug, Eq, PartialEq, Copy, Clone)]
 pub enum AttributeNameError {
     /// The provided value is empty.
     #[error("Attribute name can't be empty.")]

--- a/src/rewritable_units/tokens/capturer/text_decoder.rs
+++ b/src/rewritable_units/tokens/capturer/text_decoder.rs
@@ -65,7 +65,7 @@ impl TextDecoder {
                 emit!(self, &buffer[..written], last, event_handler)?;
             }
 
-            if let CoderResult::InputEmpty = status {
+            if status == CoderResult::InputEmpty {
                 break;
             }
 

--- a/src/rewritable_units/tokens/comment.rs
+++ b/src/rewritable_units/tokens/comment.rs
@@ -6,7 +6,7 @@ use std::fmt::{self, Debug};
 use thiserror::Error;
 
 /// An error that occurs when invalid value is provided for the HTML comment text.
-#[derive(Error, Debug, PartialEq, Copy, Clone)]
+#[derive(Error, Debug, Eq, PartialEq, Copy, Clone)]
 pub enum CommentTextError {
     /// The provided value contains the `-->` character sequence that preemptively closes the comment.
     #[error("Comment text shouldn't contain comment closing sequence (`-->`).")]

--- a/src/rewritable_units/tokens/start_tag.rs
+++ b/src/rewritable_units/tokens/start_tag.rs
@@ -58,7 +58,7 @@ impl<'i> StartTag<'i> {
 
     #[inline]
     pub fn attributes(&self) -> &[Attribute<'i>] {
-        &*self.attributes
+        &self.attributes
     }
 
     #[inline]

--- a/src/rewritable_units/tokens/text_chunk.rs
+++ b/src/rewritable_units/tokens/text_chunk.rs
@@ -86,7 +86,7 @@ impl<'i> TextChunk<'i> {
     /// Returns the textual content of the chunk.
     #[inline]
     pub fn as_str(&self) -> &str {
-        &*self.text
+        &self.text
     }
 
     /// Returns the type of the text in the chunk.

--- a/src/rewriter/mod.rs
+++ b/src/rewriter/mod.rs
@@ -301,7 +301,7 @@ mod tests {
         for chunk in chunks {
             let (chunk, _, _) = encoding.encode(chunk);
 
-            rewriter.write(&*chunk).unwrap();
+            rewriter.write(&chunk).unwrap();
         }
 
         rewriter.end().unwrap();

--- a/src/selectors_vm/compiler.rs
+++ b/src/selectors_vm/compiler.rs
@@ -435,7 +435,7 @@ mod tests {
                     "Instruction should not execute without attributes"
                 );
 
-                let multi_step_res = instr.complete_exec_with_attrs(&*state, &attr_matcher);
+                let multi_step_res = instr.complete_exec_with_attrs(state, &attr_matcher);
                 let res = instr.exec(state, &local_name, &attr_matcher);
 
                 assert_eq!(multi_step_res, res);

--- a/src/selectors_vm/error.rs
+++ b/src/selectors_vm/error.rs
@@ -3,7 +3,7 @@ use selectors::parser::{SelectorParseError, SelectorParseErrorKind};
 use thiserror::Error;
 
 /// A CSS selector parsing error.
-#[derive(Error, Debug, PartialEq, Copy, Clone)]
+#[derive(Error, Debug, Eq, PartialEq, Copy, Clone)]
 pub enum SelectorError {
     /// Unexpected token in the selector.
     #[error("Unexpected token in selector.")]

--- a/src/selectors_vm/mod.rs
+++ b/src/selectors_vm/mod.rs
@@ -634,7 +634,7 @@ mod tests {
             strict: true,
         });
 
-        transform_stream.write(&*html).unwrap();
+        transform_stream.write(&html).unwrap();
         transform_stream.end().unwrap();
     }
 

--- a/src/selectors_vm/parser.rs
+++ b/src/selectors_vm/parser.rs
@@ -8,7 +8,7 @@ use selectors::parser::{
 use std::fmt;
 use std::str::FromStr;
 
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, Eq, PartialEq)]
 pub struct SelectorImplDescriptor;
 
 impl SelectorImpl for SelectorImplDescriptor {

--- a/src/selectors_vm/program.rs
+++ b/src/selectors_vm/program.rs
@@ -49,7 +49,7 @@ where
         state: &SelectorState,
         local_name: &LocalName,
     ) -> TryExecResult<'i, P> {
-        if self.local_name_exprs.iter().all(|e| e(&*state, local_name)) {
+        if self.local_name_exprs.iter().all(|e| e(state, local_name)) {
             if self.attribute_exprs.is_empty() {
                 TryExecResult::Branch(&self.associated_branch)
             } else {
@@ -78,11 +78,8 @@ where
         local_name: &LocalName,
         attr_matcher: &AttributeMatcher,
     ) -> Option<&'i ExecutionBranch<P>> {
-        let is_match = self.local_name_exprs.iter().all(|e| e(&*state, local_name))
-            && self
-                .attribute_exprs
-                .iter()
-                .all(|e| e(&*state, attr_matcher));
+        let is_match = self.local_name_exprs.iter().all(|e| e(state, local_name))
+            && self.attribute_exprs.iter().all(|e| e(state, attr_matcher));
 
         if is_match {
             Some(&self.associated_branch)

--- a/tests/harness/suites/html5lib_tests/test_token.rs
+++ b/tests/harness/suites/html5lib_tests/test_token.rs
@@ -66,7 +66,6 @@ impl<'de> Deserialize<'de> for TestToken {
                         match seq.next_element()? {
                             Some(value) => {
                                 #[allow(unused_assignments)]
-                                #[allow(clippy::eval_order_dependence)]
                                 {
                                     actual_length += 1;
                                 }


### PR DESCRIPTION
Fix failing clippy lints, mostly adding `Eq` to `PartialEq` derives and removing Deref's that do not need to be explicit.

Also update `Cargo.lock` to match `Cargo.toml`.