### PR TITLE
Add unofficial Ruby bindings to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ https://docs.rs/lol_html/
 - [C](https://github.com/cloudflare/lol-html/tree/master/c-api)
 - [Lua](https://github.com/jdesgats/lua-lolhtml)
 - [Go](https://github.com/coolspring8/go-lolhtml) (unofficial, not coming from Cloudflare)
+- [Ruby](https://github.com/gjtorikian/selma) (unofficial, not coming from Cloudflare)
 
 ## Example
 


### PR DESCRIPTION
Hi there! I've built a project that provides Ruby bindings to this Rust library. I'm adding it to the README in the hopes that it can help others working in higher level languages access this project.