### PR TITLE
Send + Sync implentation of HtmlRewriter

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,6 +45,7 @@ safemem = "0.3.3"
 selectors = "0.22.0"
 thiserror = "1.0.2"
 hashbrown = "0.13.1"
+atomic_refcell = "0.1.9"
 
 [dev-dependencies]
 criterion = "0.4.0"

--- a/src/memory/arena.rs
+++ b/src/memory/arena.rs
@@ -63,12 +63,12 @@ impl Arena {
 mod tests {
     use super::super::limiter::MemoryLimiter;
     use super::*;
-    use std::rc::Rc;
+    use std::sync::Arc;
 
     #[test]
     fn append() {
         let limiter = MemoryLimiter::new_shared(10);
-        let mut arena = Arena::new(Rc::clone(&limiter), 2);
+        let mut arena = Arena::new(Arc::clone(&limiter), 2);
 
         arena.append(&[1, 2]).unwrap();
         assert_eq!(arena.bytes(), &[1, 2]);
@@ -90,7 +90,7 @@ mod tests {
     #[test]
     fn init_with() {
         let limiter = MemoryLimiter::new_shared(5);
-        let mut arena = Arena::new(Rc::clone(&limiter), 0);
+        let mut arena = Arena::new(Arc::clone(&limiter), 0);
 
         arena.init_with(&[1]).unwrap();
         assert_eq!(arena.bytes(), &[1]);
@@ -116,7 +116,7 @@ mod tests {
     #[test]
     fn shift() {
         let limiter = MemoryLimiter::new_shared(10);
-        let mut arena = Arena::new(Rc::clone(&limiter), 0);
+        let mut arena = Arena::new(Arc::clone(&limiter), 0);
 
         arena.append(&[0, 1, 2, 3]).unwrap();
         arena.shift(2);

--- a/src/memory/limited_vec.rs
+++ b/src/memory/limited_vec.rs
@@ -101,13 +101,13 @@ impl<T> Drop for LimitedVec<T> {
 mod tests {
     use super::super::MemoryLimiter;
     use super::*;
-    use std::rc::Rc;
+    use std::sync::Arc;
 
     #[test]
     fn current_usage() {
         {
             let limiter = MemoryLimiter::new_shared(10);
-            let mut vec_u8: LimitedVec<u8> = LimitedVec::new(Rc::clone(&limiter));
+            let mut vec_u8: LimitedVec<u8> = LimitedVec::new(Arc::clone(&limiter));
 
             vec_u8.push(1).unwrap();
             vec_u8.push(2).unwrap();
@@ -116,7 +116,7 @@ mod tests {
 
         {
             let limiter = MemoryLimiter::new_shared(10);
-            let mut vec_u32: LimitedVec<u32> = LimitedVec::new(Rc::clone(&limiter));
+            let mut vec_u32: LimitedVec<u32> = LimitedVec::new(Arc::clone(&limiter));
 
             vec_u32.push(1).unwrap();
             vec_u32.push(2).unwrap();
@@ -127,7 +127,7 @@ mod tests {
     #[test]
     fn max_limit() {
         let limiter = MemoryLimiter::new_shared(2);
-        let mut vector: LimitedVec<u8> = LimitedVec::new(Rc::clone(&limiter));
+        let mut vector: LimitedVec<u8> = LimitedVec::new(Arc::clone(&limiter));
 
         vector.push(1).unwrap();
         vector.push(2).unwrap();
@@ -142,7 +142,7 @@ mod tests {
         let limiter = MemoryLimiter::new_shared(1);
 
         {
-            let mut vector: LimitedVec<u8> = LimitedVec::new(Rc::clone(&limiter));
+            let mut vector: LimitedVec<u8> = LimitedVec::new(Arc::clone(&limiter));
 
             vector.push(1).unwrap();
             assert_eq!(limiter.borrow().current_usage(), 1);
@@ -154,7 +154,7 @@ mod tests {
     #[test]
     fn drain() {
         let limiter = MemoryLimiter::new_shared(10);
-        let mut vector: LimitedVec<u8> = LimitedVec::new(Rc::clone(&limiter));
+        let mut vector: LimitedVec<u8> = LimitedVec::new(Arc::clone(&limiter));
 
         vector.push(1).unwrap();
         vector.push(2).unwrap();

--- a/src/memory/limiter.rs
+++ b/src/memory/limiter.rs
@@ -1,8 +1,8 @@
-use std::cell::RefCell;
-use std::rc::Rc;
+use std::sync::Arc;
+use atomic_refcell::AtomicRefCell;
 use thiserror::Error;
 
-pub type SharedMemoryLimiter = Rc<RefCell<MemoryLimiter>>;
+pub type SharedMemoryLimiter = Arc<AtomicRefCell<MemoryLimiter>>;
 
 /// An error that occures when rewriter exceedes the memory limit specified in the
 /// [`MemorySettings`].
@@ -20,7 +20,7 @@ pub struct MemoryLimiter {
 
 impl MemoryLimiter {
     pub fn new_shared(max: usize) -> SharedMemoryLimiter {
-        Rc::new(RefCell::new(MemoryLimiter {
+        Arc::new(AtomicRefCell::new(MemoryLimiter {
             max,
             current_usage: 0,
         }))

--- a/src/parser/lexer/actions.rs
+++ b/src/parser/lexer/actions.rs
@@ -128,7 +128,7 @@ impl<S: LexemeSink> StateMachineActions for Lexer<S> {
             name: Range::default(),
             name_hash: LocalNameHash::new(),
             ns: Namespace::default(),
-            attributes: Rc::clone(&self.attr_buffer),
+            attributes: Arc::clone(&self.attr_buffer),
             self_closing: false,
         });
     }

--- a/src/parser/tree_builder_simulator/mod.rs
+++ b/src/parser/tree_builder_simulator/mod.rs
@@ -28,7 +28,7 @@ pub enum TreeBuilderFeedback {
     SwitchTextType(TextType),
     SetAllowCdata(bool),
     #[allow(clippy::type_complexity)]
-    RequestLexeme(Box<dyn FnMut(&mut TreeBuilderSimulator, &TagLexeme) -> TreeBuilderFeedback>),
+    RequestLexeme(Box<dyn FnMut(&mut TreeBuilderSimulator, &TagLexeme) -> TreeBuilderFeedback + Send + Sync>),
     None,
 }
 
@@ -41,7 +41,7 @@ impl From<TextType> for TreeBuilderFeedback {
 
 #[inline]
 fn request_lexeme(
-    callback: impl FnMut(&mut TreeBuilderSimulator, &TagLexeme) -> TreeBuilderFeedback + 'static,
+    callback: impl FnMut(&mut TreeBuilderSimulator, &TagLexeme) -> TreeBuilderFeedback + Send + Sync + 'static,
 ) -> TreeBuilderFeedback {
     TreeBuilderFeedback::RequestLexeme(Box::new(callback))
 }

--- a/src/rewritable_units/document_end.rs
+++ b/src/rewritable_units/document_end.rs
@@ -65,7 +65,7 @@ mod tests {
     fn rewrite_on_end(
         html: &[u8],
         encoding: &'static Encoding,
-        mut handler: impl FnMut(&mut DocumentEnd),
+        mut handler: impl FnMut(&mut DocumentEnd) + Send + Sync,
     ) -> String {
         let mut handler_called = false;
 

--- a/src/rewritable_units/element.rs
+++ b/src/rewritable_units/element.rs
@@ -488,7 +488,7 @@ impl<'r, 't> Element<'r, 't> {
     /// ```
     /// use lol_html::html_content::ContentType;
     /// use lol_html::{element, rewrite_str, text, RewriteStrSettings};
-    /// let buffer = std::rc::Rc::new(std::cell::RefCell::new(String::new()));
+    /// let buffer = std::sync::Arc::new(atomic_refcell::AtomicRefCell::new(String::new()));
     /// let html = rewrite_str(
     ///     "<span>Short</span><span><b>13</b> characters</span>",
     ///     RewriteStrSettings {
@@ -527,7 +527,7 @@ impl<'r, 't> Element<'r, 't> {
     /// ```
     pub fn on_end_tag(
         &mut self,
-        handler: impl FnOnce(&mut EndTag) -> HandlerResult + 'static,
+        handler: impl FnOnce(&mut EndTag) -> HandlerResult + Send + Sync + 'static,
     ) -> Result<(), EndTagError> {
         if self.can_have_content {
             self.end_tag_handler = Some(Box::new(handler));
@@ -590,7 +590,7 @@ mod tests {
         html: &[u8],
         encoding: &'static Encoding,
         selector: &str,
-        mut handler: impl FnMut(&mut Element),
+        mut handler: impl FnMut(&mut Element) + Send + Sync,
     ) -> String {
         let mut handler_called = false;
 

--- a/src/rewritable_units/mod.rs
+++ b/src/rewritable_units/mod.rs
@@ -54,7 +54,7 @@ pub trait UserData {
     /// Returns a mutable reference to the attached user data.
     fn user_data_mut(&mut self) -> &mut dyn Any;
     /// Attaches user data to a rewritable unit.
-    fn set_user_data(&mut self, data: impl Any);
+    fn set_user_data(&mut self, data: impl Any + Send + Sync);
 }
 
 macro_rules! impl_user_data {
@@ -71,7 +71,7 @@ macro_rules! impl_user_data {
             }
 
             #[inline]
-            fn set_user_data(&mut self, data: impl Any){
+            fn set_user_data(&mut self, data: impl Any + Send + Sync){
                 self.user_data = Box::new(data);
             }
         }

--- a/src/rewritable_units/tokens/attributes.rs
+++ b/src/rewritable_units/tokens/attributes.rs
@@ -222,7 +222,7 @@ impl<'i> Attributes<'i> {
 
     #[cfg(test)]
     pub fn raw_attributes(&self) -> (&'i Bytes<'i>, SharedAttributeBuffer) {
-        (self.input, std::rc::Rc::clone(&self.attribute_buffer))
+        (self.input, std::sync::Arc::clone(&self.attribute_buffer))
     }
 }
 

--- a/src/rewritable_units/tokens/capturer/to_token.rs
+++ b/src/rewritable_units/tokens/capturer/to_token.rs
@@ -1,8 +1,9 @@
+use std::sync::Arc;
+
 use super::*;
 use crate::html::TextType;
 use crate::parser::{NonTagContentLexeme, NonTagContentTokenOutline, TagLexeme, TagTokenOutline};
 use encoding_rs::Encoding;
-use std::rc::Rc;
 
 pub enum ToTokenResult<'i> {
     Token(Box<Token<'i>>),
@@ -44,7 +45,7 @@ impl ToToken for TagLexeme<'_> {
 
                 StartTag::new_token(
                     self.part(name),
-                    Attributes::new(self.input(), Rc::clone(attributes), encoding),
+                    Attributes::new(self.input(), Arc::clone(attributes), encoding),
                     ns,
                     self_closing,
                     self.raw(),

--- a/src/rewritable_units/tokens/comment.rs
+++ b/src/rewritable_units/tokens/comment.rs
@@ -216,7 +216,7 @@ mod tests {
     fn rewrite_comment(
         html: &[u8],
         encoding: &'static Encoding,
-        mut handler: impl FnMut(&mut Comment),
+        mut handler: impl FnMut(&mut Comment) + Send + Sync,
     ) -> String {
         let mut handler_called = false;
 

--- a/src/rewritable_units/tokens/doctype.rs
+++ b/src/rewritable_units/tokens/doctype.rs
@@ -39,7 +39,7 @@ pub struct Doctype<'i> {
     removed: bool,
     raw: Bytes<'i>,
     encoding: &'static Encoding,
-    user_data: Box<dyn Any>,
+    user_data: Box<dyn Any + Send + Sync>,
 }
 
 impl<'i> Doctype<'i> {
@@ -136,7 +136,7 @@ mod tests {
     fn rewrite_doctype(
         html: &[u8],
         encoding: &'static Encoding,
-        mut handler: impl FnMut(&mut Doctype),
+        mut handler: impl FnMut(&mut Doctype) + Send + Sync,
     ) -> String {
         let mut handler_called = false;
 

--- a/src/rewritable_units/tokens/text_chunk.rs
+++ b/src/rewritable_units/tokens/text_chunk.rs
@@ -284,7 +284,7 @@ mod tests {
     fn rewrite_text_chunk(
         html: &[u8],
         encoding: &'static Encoding,
-        mut handler: impl FnMut(&mut TextChunk),
+        mut handler: impl FnMut(&mut TextChunk) + Send + Sync,
     ) -> String {
         let mut handler_called = false;
 

--- a/src/rewriter/settings.rs
+++ b/src/rewriter/settings.rs
@@ -6,12 +6,12 @@ use std::borrow::Cow;
 use std::error::Error;
 
 pub(crate) type HandlerResult = Result<(), Box<dyn Error + Send + Sync>>;
-pub type DoctypeHandler<'h> = Box<dyn FnMut(&mut Doctype) -> HandlerResult + 'h>;
-pub type CommentHandler<'h> = Box<dyn FnMut(&mut Comment) -> HandlerResult + 'h>;
-pub type TextHandler<'h> = Box<dyn FnMut(&mut TextChunk) -> HandlerResult + 'h>;
-pub type ElementHandler<'h> = Box<dyn FnMut(&mut Element) -> HandlerResult + 'h>;
-pub type EndTagHandler<'h> = Box<dyn FnOnce(&mut EndTag) -> HandlerResult + 'h>;
-pub type EndHandler<'h> = Box<dyn FnOnce(&mut DocumentEnd) -> HandlerResult + 'h>;
+pub type DoctypeHandler<'h> = Box<dyn FnMut(&mut Doctype) -> HandlerResult + Send + Sync + 'h>;
+pub type CommentHandler<'h> = Box<dyn FnMut(&mut Comment) -> HandlerResult + Send + Sync + 'h>;
+pub type TextHandler<'h> = Box<dyn FnMut(&mut TextChunk) -> HandlerResult + Send + Sync + 'h>;
+pub type ElementHandler<'h> = Box<dyn FnMut(&mut Element) -> HandlerResult + Send + Sync + 'h>;
+pub type EndTagHandler<'h> = Box<dyn FnOnce(&mut EndTag) -> HandlerResult + Send + Sync + 'h>;
+pub type EndHandler<'h> = Box<dyn FnOnce(&mut DocumentEnd) -> HandlerResult + Send + Sync + 'h>;
 
 /// Specifies element content handlers associated with a selector.
 #[derive(Default)]
@@ -24,7 +24,7 @@ pub struct ElementContentHandlers<'h> {
 impl<'h> ElementContentHandlers<'h> {
     /// Sets a handler for elements matched by a selector.
     #[inline]
-    pub fn element(mut self, handler: impl FnMut(&mut Element) -> HandlerResult + 'h) -> Self {
+    pub fn element(mut self, handler: impl FnMut(&mut Element) -> HandlerResult + Send + Sync + 'h) -> Self {
         self.element = Some(Box::new(handler));
 
         self
@@ -32,7 +32,7 @@ impl<'h> ElementContentHandlers<'h> {
 
     /// Sets a handler for HTML comments in the inner content of elements matched by a selector.
     #[inline]
-    pub fn comments(mut self, handler: impl FnMut(&mut Comment) -> HandlerResult + 'h) -> Self {
+    pub fn comments(mut self, handler: impl FnMut(&mut Comment) -> HandlerResult + Send + Sync + 'h) -> Self {
         self.comments = Some(Box::new(handler));
 
         self
@@ -40,7 +40,7 @@ impl<'h> ElementContentHandlers<'h> {
 
     /// Sets a handler for text chunks in the inner content of elements matched by a selector.
     #[inline]
-    pub fn text(mut self, handler: impl FnMut(&mut TextChunk) -> HandlerResult + 'h) -> Self {
+    pub fn text(mut self, handler: impl FnMut(&mut TextChunk) -> HandlerResult + Send + Sync + 'h) -> Self {
         self.text = Some(Box::new(handler));
 
         self
@@ -75,7 +75,7 @@ impl<'h> DocumentContentHandlers<'h> {
     ///
     /// [document type declaration]: https://developer.mozilla.org/en-US/docs/Glossary/Doctype
     #[inline]
-    pub fn doctype(mut self, handler: impl FnMut(&mut Doctype) -> HandlerResult + 'h) -> Self {
+    pub fn doctype(mut self, handler: impl FnMut(&mut Doctype) -> HandlerResult + Send + Sync + 'h) -> Self {
         self.doctype = Some(Box::new(handler));
 
         self
@@ -83,7 +83,7 @@ impl<'h> DocumentContentHandlers<'h> {
 
     /// Sets a handler for all HTML comments present in the input HTML markup.
     #[inline]
-    pub fn comments(mut self, handler: impl FnMut(&mut Comment) -> HandlerResult + 'h) -> Self {
+    pub fn comments(mut self, handler: impl FnMut(&mut Comment) -> HandlerResult + Send + Sync + 'h) -> Self {
         self.comments = Some(Box::new(handler));
 
         self
@@ -91,7 +91,7 @@ impl<'h> DocumentContentHandlers<'h> {
 
     /// Sets a handler for all text chunks present in the input HTML markup.
     #[inline]
-    pub fn text(mut self, handler: impl FnMut(&mut TextChunk) -> HandlerResult + 'h) -> Self {
+    pub fn text(mut self, handler: impl FnMut(&mut TextChunk) -> HandlerResult + Send + Sync + 'h) -> Self {
         self.text = Some(Box::new(handler));
 
         self
@@ -99,7 +99,7 @@ impl<'h> DocumentContentHandlers<'h> {
 
     /// Sets a handler for the document end, which is called after the last chunk is processed.
     #[inline]
-    pub fn end(mut self, handler: impl FnMut(&mut DocumentEnd) -> HandlerResult + 'h) -> Self {
+    pub fn end(mut self, handler: impl FnMut(&mut DocumentEnd) -> HandlerResult + Send + Sync + 'h) -> Self {
         self.end = Some(Box::new(handler));
 
         self

--- a/src/selectors_vm/stack.rs
+++ b/src/selectors_vm/stack.rs
@@ -37,7 +37,7 @@ fn is_void_element(local_name: &LocalName, enable_esi_tags: bool) -> bool {
     false
 }
 
-pub trait ElementData: Default + 'static {
+pub trait ElementData: Default + Send + Sync + 'static {
     type MatchPayload: PartialEq + Eq + Copy + Debug + Hash + 'static;
 
     fn matched_payload_mut(&mut self) -> &mut HashSet<Self::MatchPayload>;

--- a/src/transform_stream/mod.rs
+++ b/src/transform_stream/mod.rs
@@ -4,9 +4,9 @@ use self::dispatcher::Dispatcher;
 use crate::memory::{Arena, SharedMemoryLimiter};
 use crate::parser::{Parser, ParserDirective, SharedAttributeBuffer};
 use crate::rewriter::RewritingError;
+use atomic_refcell::AtomicRefCell;
 use encoding_rs::Encoding;
-use std::cell::RefCell;
-use std::rc::Rc;
+use std::sync::Arc;
 
 pub use self::dispatcher::{
     AuxStartTagInfo, DispatcherError, OutputSink, StartTagHandlingResult, TransformController,
@@ -30,7 +30,7 @@ where
     C: TransformController,
     O: OutputSink,
 {
-    dispatcher: Rc<RefCell<Dispatcher<C, O>>>,
+    dispatcher: Arc<AtomicRefCell<Dispatcher<C, O>>>,
     parser: Parser<Dispatcher<C, O>>,
     buffer: Arena,
     has_buffered_data: bool,
@@ -52,7 +52,7 @@ where
             ParserDirective::Lex
         };
 
-        let dispatcher = Rc::new(RefCell::new(Dispatcher::new(
+        let dispatcher = Arc::new(AtomicRefCell::new(Dispatcher::new(
             settings.transform_controller,
             settings.output_sink,
             settings.encoding,


### PR DESCRIPTION
A few days ago, I came across this crate when I was researching methods of applying regular expression onto an HTML stream. I was really excited to see that this hard problem was actually solvable using this crate. 
I sadly realized that the [`HtmlRewriter`](https://docs.rs/lol_html/0.3.2/lol_html/struct.HtmlRewriter.html) is nether Send nor Sync, so it is almost impossible to us it in combination with futures. 

So I decided to try to do a basic rewrite of the crate into a Send and Sync implementation. It currently compiles and all the tests pass. 

Although I refrained from using any RwLock's or Mutex's, there are some minor/major performance and throughput regressions, I attached an output file of a run I did using the script/bench.sh benchmark. 
[benchmark.txt](https://github.com/cloudflare/lol-html/files/10922950/benchmark.txt)

This and the bounds required for the [`HtmlRewriter`](https://docs.rs/lol_html/0.3.2/lol_html/struct.HtmlRewriter.html)  to be Send and Sync make it probably moronic to merge it directly into the lol-html crate. 
But it would be possible to put it behind a feature flag with almost no downsides for developers and users. 

This is the reason for the Pull request, do you guys think a Send and Sync version of the [`HtmlRewriter`](https://docs.rs/lol_html/0.3.2/lol_html/struct.HtmlRewriter.html) behind a feature flag would be mergeable? 
I ask because I would have to put in some effort and time to not just duplicate some code a bunch of time (Send and non Send versions).

Thank you very much in advance, I am looking forward to hearing back from you.