### PR TITLE
Fix `afl` and `honggfuzz` fuzzing scripts

### DIFF
--- a/scripts/fuzz_with_afl.sh
+++ b/scripts/fuzz_with_afl.sh
@@ -4,9 +4,9 @@ set -eu
 
 cargo +nightly install afl
 (
-	cd ./c-api
-	# ok to use default toolchain here since C ABI is stable
-	cargo build
+    cd ./c-api
+    # ok to use default toolchain here since C ABI is stable
+    cargo build
 )
 LOLHTML_LIB_PATH="$(realpath ${CARGO_TARGET_DIR:-c-api/target}/debug/deps)"
 # add `liblolhtml.so` to compiling linker path

--- a/scripts/fuzz_with_afl.sh
+++ b/scripts/fuzz_with_afl.sh
@@ -14,7 +14,7 @@ export RUSTFLAGS="-L $LOLHTML_LIB_PATH"
 # add `liblolhtml.so` to runtime linker path
 export LD_LIBRARY_PATH="$LOLHTML_LIB_PATH"
 (
-	cd ./fuzz/afl
-	cargo +nightly afl build
+    cd ./fuzz/afl
+    cargo +nightly afl build
     cargo +nightly afl fuzz -x ../dictionaries -i ../corpus/selector_matching -o out target/debug/afl-fuzz
 )

--- a/scripts/fuzz_with_afl.sh
+++ b/scripts/fuzz_with_afl.sh
@@ -1,7 +1,20 @@
 #!/bin/sh
 
-set -e
+set -eu
 
-cd ./fuzz/afl && \
-cargo +nightly afl build && \
-RUSTFLAGS="-Z sanitizer=address" cargo +nightly afl fuzz -x ../dictionaries -i ../corpus/selector_matching -o out target/debug/afl-fuzz
+cargo +nightly install afl
+(
+	cd ./c-api
+	# ok to use default toolchain here since C ABI is stable
+	cargo build
+)
+LOLHTML_LIB_PATH="$(realpath ${CARGO_TARGET_DIR:-c-api/target}/debug/deps)"
+# add `liblolhtml.so` to compiling linker path
+export RUSTFLAGS="-L $LOLHTML_LIB_PATH"
+# add `liblolhtml.so` to runtime linker path
+export LD_LIBRARY_PATH="$LOLHTML_LIB_PATH"
+(
+	cd ./fuzz/afl
+	cargo +nightly afl build
+    cargo +nightly afl fuzz -x ../dictionaries -i ../corpus/selector_matching -o out target/debug/afl-fuzz
+)

--- a/scripts/fuzz_with_hongg.sh
+++ b/scripts/fuzz_with_hongg.sh
@@ -1,7 +1,22 @@
 #!/bin/sh
 
-set -e
+set -eu
 
-cd ./fuzz/hongg && \
-cargo +nightly build && \
-RUSTFLAGS="-Z sanitizer=address" HFUZZ_RUN_ARGS="--threads=4" HFUZZ_INPUT=../corpus/selector_matching cargo +nightly hfuzz run hongg
+# In case you're missing libraries, do:
+# sudo apt-get install binutils-dev libunwind-dev
+cargo +nightly install honggfuzz
+(
+	cd ./c-api
+	# ok to use default toolchain here since C ABI is stable
+	cargo build
+)
+LOLHTML_LIB_PATH="$(realpath ${CARGO_TARGET_DIR:-c-api/target}/debug/deps)"
+# add `liblolhtml.so` to compiling linker path
+export RUSTFLAGS="-L $LOLHTML_LIB_PATH"
+# add `liblolhtml.so` to runtime linker path
+export LD_LIBRARY_PATH="$LOLHTML_LIB_PATH"
+(
+	cd ./fuzz/hongg
+	cargo +nightly build
+    HFUZZ_INPUT=../corpus/selector_matching cargo +nightly hfuzz run hongg
+)

--- a/scripts/fuzz_with_hongg.sh
+++ b/scripts/fuzz_with_hongg.sh
@@ -16,7 +16,7 @@ export RUSTFLAGS="-L $LOLHTML_LIB_PATH"
 # add `liblolhtml.so` to runtime linker path
 export LD_LIBRARY_PATH="$LOLHTML_LIB_PATH"
 (
-	cd ./fuzz/hongg
-	cargo +nightly build
+    cd ./fuzz/hongg
+    cargo +nightly build
     HFUZZ_INPUT=../corpus/selector_matching cargo +nightly hfuzz run hongg
 )

--- a/scripts/fuzz_with_hongg.sh
+++ b/scripts/fuzz_with_hongg.sh
@@ -6,9 +6,9 @@ set -eu
 # sudo apt-get install binutils-dev libunwind-dev
 cargo +nightly install honggfuzz
 (
-	cd ./c-api
-	# ok to use default toolchain here since C ABI is stable
-	cargo build
+    cd ./c-api
+    # ok to use default toolchain here since C ABI is stable
+    cargo build
 )
 LOLHTML_LIB_PATH="$(realpath ${CARGO_TARGET_DIR:-c-api/target}/debug/deps)"
 # add `liblolhtml.so` to compiling linker path


### PR DESCRIPTION
This commit fixes the broken `afl` fuzzing script by adding  `lolhtml` library at the linking stage and runtime.