### PR TITLE
Fix lol_html_take_last_error() after calling lol_html_element_add_end_tag_handler() on element with no end tag

### DIFF
--- a/c-api/include/lol_html.h
+++ b/c-api/include/lol_html.h
@@ -696,6 +696,10 @@ void *lol_html_element_user_data_get(const lol_html_element_t *element);
 // stops immediately and `write()` or `end()` of the rewriter methods
 // return an error code.
 //
+// Not all elements (for example, `<br>`) support end tags. If this function is
+// called on such an element, this function returns an error code as described
+// below.
+//
 // Returns 0 in case of success and -1 otherwise. The actual error message
 // can be obtained using `lol_html_take_last_error` function.
 //

--- a/c-api/src/element.rs
+++ b/c-api/src/element.rs
@@ -228,18 +228,18 @@ pub extern "C" fn lol_html_element_add_end_tag_handler(
 ) -> c_int {
     let element = to_ref_mut!(element);
 
-    match element.end_tag_handlers() {
-        Some(handlers) => {
-            handlers.push(Box::new(move |end_tag| {
-                match unsafe { handler(end_tag, user_data) } {
-                    RewriterDirective::Continue => Ok(()),
-                    RewriterDirective::Stop => Err("The rewriter has been stopped.".into()),
-                }
-            }));
-            0
+    let handlers = unwrap_or_ret_err_code! {
+        element.end_tag_handlers().ok_or("No end tag.")
+    };
+
+    handlers.push(Box::new(move |end_tag| {
+        match unsafe { handler(end_tag, user_data) } {
+            RewriterDirective::Continue => Ok(()),
+            RewriterDirective::Stop => Err("The rewriter has been stopped.".into()),
         }
-        None => -1,
-    }
+    }));
+
+    0
 }
 
 #[no_mangle]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -52,8 +52,8 @@ pub mod errors {
 /// HTML content descriptors that can be produced and modified by a rewriter.
 pub mod html_content {
     pub use super::rewritable_units::{
-        Attribute, Comment, ContentType, Doctype, DocumentEnd, Element, EndTag, EndTagError,
-        StartTag, TextChunk, UserData,
+        Attribute, Comment, ContentType, Doctype, DocumentEnd, Element, EndTag, StartTag,
+        TextChunk, UserData,
     };
 
     pub use super::html::TextType;

--- a/src/rewritable_units/element.rs
+++ b/src/rewritable_units/element.rs
@@ -30,14 +30,6 @@ pub enum TagNameError {
     UnencodableCharacter,
 }
 
-/// An error that occurs when invalid value is provided for the tag name.
-#[derive(Error, Debug, Eq, PartialEq, Copy, Clone)]
-pub enum EndTagError {
-    /// The tag has no end tag.
-    #[error("No end tag.")]
-    NoEndTag,
-}
-
 /// An HTML element rewritable unit.
 ///
 /// Exposes API for examination and modification of a parsed HTML element.


### PR DESCRIPTION
PR #182 included a tiny regression: https://github.com/cloudflare/lol-html/pull/182#discussion_r1221337721

I hacked a little fix together. Suggestions for greater elegance are welcome. :)