### PR TITLE
Avoid using a `Rc<RefCell<_>>` in `HtmlRewriteController::handlers_dispatcher()`.

### DIFF
--- a/src/rewriter/settings.rs
+++ b/src/rewriter/settings.rs
@@ -418,7 +418,7 @@ impl Default for MemorySettings {
     fn default() -> Self {
         MemorySettings {
             preallocated_parsing_buffer_size: 1024,
-            max_allowed_memory_usage: std::usize::MAX,
+            max_allowed_memory_usage: usize::MAX,
         }
     }
 }

--- a/tests/harness/suites/html5lib_tests/decoder.rs
+++ b/tests/harness/suites/html5lib_tests/decoder.rs
@@ -92,11 +92,8 @@ impl<'a> Decoder<'a> {
                 if m.0 != 0 {
                     if c != ';' && self.entities == Entities::Attribute {
                         if let Some(&c) = self.chars.peek() {
-                            match c {
-                                'A'..='Z' | 'a'..='z' | '0'..='9' | '=' => {
-                                    continue;
-                                }
-                                _ => {}
+                            if matches!(c, 'A'..='Z' | 'a'..='z' | '0'..='9' | '=') {
+                                continue;
                             }
                         }
                     }


### PR DESCRIPTION
This means one less lock in a potential `Send + Sync` version of the rewriter.