### PR TITLE
Removed RefCells for dispatcher.

### DIFF
--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -6,105 +6,67 @@ mod tag_scanner;
 mod tree_builder_simulator;
 
 use self::lexer::Lexer;
-use self::state_machine::{ActionError, ParsingTermination, StateMachine};
-use self::tag_scanner::TagScanner;
-use self::tree_builder_simulator::{TreeBuilderFeedback, TreeBuilderSimulator};
-use crate::html::{LocalName, Namespace};
-use crate::rewriter::RewritingError;
-use cfg_if::cfg_if;
-use std::cell::RefCell;
-use std::rc::Rc;
-
 pub use self::lexer::{
     AttributeOutline, Lexeme, LexemeSink, NonTagContentLexeme, NonTagContentTokenOutline,
     SharedAttributeBuffer, TagLexeme, TagTokenOutline,
 };
+use self::state_machine::{ActionError, ParsingTermination, StateMachine};
 pub use self::tag_scanner::TagHintSink;
+use self::tag_scanner::TagScanner;
 pub use self::tree_builder_simulator::ParsingAmbiguityError;
+use self::tree_builder_simulator::{TreeBuilderFeedback, TreeBuilderSimulator};
+use crate::rewriter::RewritingError;
+use cfg_if::cfg_if;
 
 // NOTE: tag scanner can implicitly force parser to switch to
 // the lexer mode if it fails to get tree builder feedback. It's up
 // to consumer to switch the parser back to the tag scan mode in
 // the tag handler.
-#[derive(Debug)]
+#[derive(Clone, Copy, Debug)]
 pub enum ParserDirective {
     WherePossibleScanForTagsOnly,
     Lex,
 }
 
-impl<S: LexemeSink> LexemeSink for Rc<RefCell<S>> {
-    #[inline]
-    fn handle_tag(&mut self, lexeme: &TagLexeme) -> Result<ParserDirective, RewritingError> {
-        self.borrow_mut().handle_tag(lexeme)
-    }
-
-    #[inline]
-    fn handle_non_tag_content(
-        &mut self,
-        lexeme: &NonTagContentLexeme,
-    ) -> Result<(), RewritingError> {
-        self.borrow_mut().handle_non_tag_content(lexeme)
-    }
-}
-
-impl<S: TagHintSink> TagHintSink for Rc<RefCell<S>> {
-    #[inline]
-    fn handle_start_tag_hint(
-        &mut self,
-        name: LocalName,
-        ns: Namespace,
-    ) -> Result<ParserDirective, RewritingError> {
-        self.borrow_mut().handle_start_tag_hint(name, ns)
-    }
-
-    #[inline]
-    fn handle_end_tag_hint(&mut self, name: LocalName) -> Result<ParserDirective, RewritingError> {
-        self.borrow_mut().handle_end_tag_hint(name)
-    }
+pub struct ParserContext<S> {
+    output_sink: S,
+    tree_builder_simulator: TreeBuilderSimulator,
 }
 
 pub trait ParserOutputSink: LexemeSink + TagHintSink {}
 
 pub struct Parser<S: ParserOutputSink> {
-    lexer: Lexer<Rc<RefCell<S>>>,
-    tag_scanner: TagScanner<Rc<RefCell<S>>>,
+    lexer: Lexer<S>,
+    tag_scanner: TagScanner<S>,
     current_directive: ParserDirective,
-}
-
-// NOTE: dynamic dispatch can't be used for the StateMachine trait
-// because it's not object-safe due to the usage of `Self` in function
-// signatures, so we use this macro instead.
-macro_rules! with_current_sm {
-    ($self:tt, sm.$fn:ident($($args:tt)*) ) => {
-        match $self.current_directive {
-            ParserDirective::WherePossibleScanForTagsOnly => $self.tag_scanner.$fn($($args)*),
-            ParserDirective::Lex => $self.lexer.$fn($($args)*),
-        }
-    };
+    context: ParserContext<S>,
 }
 
 impl<S: ParserOutputSink> Parser<S> {
-    pub fn new(
-        output_sink: &Rc<RefCell<S>>,
-        initial_directive: ParserDirective,
-        strict: bool,
-    ) -> Self {
-        let tree_builder_simulator = Rc::new(RefCell::new(TreeBuilderSimulator::new(strict)));
+    pub fn new(output_sink: S, initial_directive: ParserDirective, strict: bool) -> Self {
+        let context = ParserContext {
+            output_sink,
+            tree_builder_simulator: TreeBuilderSimulator::new(strict),
+        };
 
         Parser {
-            lexer: Lexer::new(Rc::clone(output_sink), Rc::clone(&tree_builder_simulator)),
-            tag_scanner: TagScanner::new(
-                Rc::clone(output_sink),
-                Rc::clone(&tree_builder_simulator),
-            ),
+            lexer: Lexer::new(),
+            tag_scanner: TagScanner::new(),
             current_directive: initial_directive,
+            context,
         }
     }
 
     pub fn parse(&mut self, input: &[u8], last: bool) -> Result<usize, RewritingError> {
         use ActionError::*;
 
-        let mut parse_result = with_current_sm!(self, sm.run_parsing_loop(input, last));
+        let mut parse_result = match self.current_directive {
+            ParserDirective::WherePossibleScanForTagsOnly => {
+                self.tag_scanner
+                    .run_parsing_loop(&mut self.context, input, last)
+            }
+            ParserDirective::Lex => self.lexer.run_parsing_loop(&mut self.context, input, last),
+        };
 
         loop {
             match parse_result {
@@ -121,13 +83,26 @@ impl<S: ParserOutputSink> Parser<S> {
 
                     trace!(@continue_from_bookmark sm_bookmark, self.current_directive, input);
 
-                    parse_result =
-                        with_current_sm!(self, sm.continue_from_bookmark(input, last, sm_bookmark));
+                    parse_result = match self.current_directive {
+                        ParserDirective::WherePossibleScanForTagsOnly => self
+                            .tag_scanner
+                            .continue_from_bookmark(&mut self.context, input, last, sm_bookmark),
+                        ParserDirective::Lex => self.lexer.continue_from_bookmark(
+                            &mut self.context,
+                            input,
+                            last,
+                            sm_bookmark,
+                        ),
+                    };
                 }
                 Err(ParsingTermination::ActionError(RewritingError(err))) => return Err(err),
                 Ok(unreachable) => match unreachable {},
             }
         }
+    }
+
+    pub fn get_dispatcher(&mut self) -> &mut S {
+        &mut self.context.output_sink
     }
 }
 
@@ -137,11 +112,21 @@ cfg_if! {
 
         impl<S: ParserOutputSink> Parser<S> {
             pub fn switch_text_type(&mut self, text_type: TextType) {
-                with_current_sm!(self, sm.switch_text_type(text_type));
+                match self.current_directive {
+                    ParserDirective::WherePossibleScanForTagsOnly => {
+                        self.tag_scanner.switch_text_type(text_type)
+                    }
+                    ParserDirective::Lex => self.lexer.switch_text_type(text_type),
+                }
             }
 
             pub fn set_last_start_tag_name_hash(&mut self, name_hash: LocalNameHash) {
-                with_current_sm!(self, sm.set_last_start_tag_name_hash(name_hash));
+                match self.current_directive {
+                    ParserDirective::WherePossibleScanForTagsOnly => {
+                        self.tag_scanner.set_last_start_tag_name_hash(name_hash)
+                    }
+                    ParserDirective::Lex => self.lexer.set_last_start_tag_name_hash(name_hash),
+                }
             }
         }
     }

--- a/src/parser/state_machine/syntax_dsl/action.rs
+++ b/src/parser/state_machine/syntax_dsl/action.rs
@@ -1,23 +1,23 @@
 macro_rules! action {
-    (| $self:tt, $input:ident | > $action_fn:ident ? $($args:expr),* ) => {
-        $self.$action_fn($input $(,$args),*).map_err(ParsingTermination::ActionError)?;
+    (| $self:tt, $ctx:tt, $input:ident | > $action_fn:ident ? $($args:expr),* ) => {
+        $self.$action_fn($ctx, $input $(,$args),*).map_err(ParsingTermination::ActionError)?;
     };
 
-    (| $self:tt, $input:ident | > $action_fn:ident $($args:expr),* ) => {
-        $self.$action_fn($input $(,$args),*);
+    (| $self:tt, $ctx:tt, $input:ident | > $action_fn:ident $($args:expr),* ) => {
+        $self.$action_fn($ctx, $input $(,$args),*);
     };
 
-    ( @state_transition | $self:tt, $input:ident | > reconsume in $state:ident) => {
+    ( @state_transition | $self:tt, $ctx:tt, $input:ident | > reconsume in $state:ident) => {
         $self.unconsume_ch();
-        action!(@state_transition | $self, $input | > --> $state);
+        action!(@state_transition | $self, $ctx, $input | > --> $state);
     };
 
-    ( @state_transition | $self:tt, $input:ident | > - -> $state:ident) => {
+    ( @state_transition | $self:tt, $ctx:tt, $input:ident | > - -> $state:ident) => {
         $self.switch_state(Self::$state);
         return Ok(());
     };
 
-    ( @state_transition | $self:tt, $input:ident | > - -> dyn $state_getter:ident) => {
+    ( @state_transition | $self:tt, $ctx:tt, $input:ident | > - -> dyn $state_getter:ident) => {
         {
             let state = $self.$state_getter();
             $self.switch_state(state);

--- a/src/parser/state_machine/syntax_dsl/action_list.rs
+++ b/src/parser/state_machine/syntax_dsl/action_list.rs
@@ -1,50 +1,50 @@
 macro_rules! action_list {
-    ( | $self:tt, $input:ident |>
+    ( | $self:tt, $ctx:tt, $input:ident |>
         if $cond:ident
             ( $($if_actions:tt)* )
         else
             ( $($else_actions:tt)* )
     ) => {
         if $self.$cond() {
-            action_list!(| $self, $input |> $($if_actions)*);
+            action_list!(| $self, $ctx, $input |> $($if_actions)*);
         } else {
-            action_list!(| $self, $input |> $($else_actions)*);
+            action_list!(| $self, $ctx, $input |> $($else_actions)*);
         }
     };
 
-    ( | $self:tt, $input:ident |> { $($code_block:tt)* } ) => ( $($code_block)* );
+    ( | $self:tt, $ctx:tt, $input:ident |> { $($code_block:tt)* } ) => ( $($code_block)* );
 
-    ( | $self:tt, $input:ident |> $action:ident $($args:expr),*; $($rest:tt)* ) => {
+    ( | $self:tt, $ctx:tt, $input:ident |> $action:ident $($args:expr),*; $($rest:tt)* ) => {
         trace!(@actions $action $($args:expr)*);
-        action!(| $self, $input |> $action $($args),*);
-        action_list!(| $self, $input |> $($rest)*);
+        action!(| $self, $ctx, $input |> $action $($args),*);
+        action_list!(| $self, $ctx, $input |> $($rest)*);
     };
 
-     ( | $self:tt, $input:ident |> $action:ident ? $($args:expr),*; $($rest:tt)* ) => {
+     ( | $self:tt, $ctx:tt, $input:ident |> $action:ident ? $($args:expr),*; $($rest:tt)* ) => {
         trace!(@actions $action $($args:expr)*);
-        action!(| $self, $input |> $action ? $($args),*);
-        action_list!(| $self, $input |> $($rest)*);
+        action!(| $self, $ctx, $input |> $action ? $($args),*);
+        action_list!(| $self, $ctx, $input |> $($rest)*);
     };
 
     // NOTE: state transition should always be in the end of the action list
-    ( | $self:tt, $input:ident|> $($transition:tt)+ ) => {
+    ( | $self:tt, $ctx:tt, $input:ident|> $($transition:tt)+ ) => {
         trace!(@actions $($transition)+);
-        action!(@state_transition | $self, $input |> $($transition)+);
+        action!(@state_transition | $self, $ctx, $input |> $($transition)+);
     };
 
     // NOTE: end of the action list
-    ( | $self:tt, $input:ident |> ) => ();
+    ( | $self:tt, $ctx:tt, $input:ident |> ) => ();
 
 
     // State enter action list
     //--------------------------------------------------------------------
-    ( @state_enter | $self:tt, $input:ident |> $($actions:tt)+ ) => {
+    ( @state_enter | $self:tt, $ctx:tt, $input:ident |> $($actions:tt)+ ) => {
         if $self.is_state_enter() {
-            action_list!(|$self, $input|> $($actions)*);
+            action_list!(|$self, $ctx, $input|> $($actions)*);
             $self.set_is_state_enter(false);
         }
     };
 
     // NOTE: don't generate any code for the empty action list
-    ( @state_enter | $self:tt, $input:ident |> ) => ();
+    ( @state_enter | $self:tt, $ctx:tt, $input:ident |> ) => ();
 }

--- a/src/parser/state_machine/syntax_dsl/arm_pattern/mod.rs
+++ b/src/parser/state_machine/syntax_dsl/arm_pattern/mod.rs
@@ -16,21 +16,21 @@ macro_rules! arm_pattern {
         );
     };
 
-    ( | [ [$self:tt, $input_chunk:ident, $ch:ident ], $($rest_cb_args:tt)+ ] |>
+    ( | [ [$self:tt, $ctx:tt, $input_chunk:ident, $ch:ident ], $($rest_cb_args:tt)+ ] |>
         closing_quote => $actions:tt
     ) => {
-        state_body!(@callback | [ [$self, $input_chunk, $ch], $($rest_cb_args)+ ] |>
+        state_body!(@callback | [ [$self, $ctx, $input_chunk, $ch], $($rest_cb_args)+ ] |>
             Some(ch) if ch == $self.closing_quote() => $actions
         );
     };
 
 
-    ( | [ [$self:tt, $input:ident, $ch:ident ], $($rest_cb_args:tt)+ ] |>
+    ( | [ [$self:tt, $ctx:tt, $input:ident, $ch:ident ], $($rest_cb_args:tt)+ ] |>
         eoc => ( $($actions:tt)* )
     ) => {
-        state_body!(@callback | [ [$self, $input, $ch], $($rest_cb_args)+ ] |>
+        state_body!(@callback | [ [$self, $ctx, $input, $ch], $($rest_cb_args)+ ] |>
             None if !$self.is_last_input() => ({
-                action_list!(|$self, $input|> $($actions)* );
+                action_list!(|$self, $ctx, $input|> $($actions)* );
 
                 return $self.break_on_end_of_input($input);
             })
@@ -41,13 +41,13 @@ macro_rules! arm_pattern {
     // so it's safe to break parsing loop here, since we don't have any input left
     // to parse. We execute EOF actions only if it's a last input, otherwise we just
     // break the parsing loop if it hasn't been done by the explicit EOC arm.
-    ( | [ [$self:tt, $input:ident, $ch:ident ], $($rest_cb_args:tt)+ ] |>
+    ( | [ [$self:tt, $ctx:tt, $input:ident, $ch:ident ], $($rest_cb_args:tt)+ ] |>
         eof => ( $($actions:tt)* )
     ) => {
-        state_body!(@callback | [ [$self, $input, $ch], $($rest_cb_args)+ ] |>
+        state_body!(@callback | [ [$self, $ctx, $input, $ch], $($rest_cb_args)+ ] |>
             None => ({
                 if $self.is_last_input() {
-                    action_list!(|$self, $input|> $($actions)* );
+                    action_list!(|$self, $ctx, $input|> $($actions)* );
                 }
 
                 return $self.break_on_end_of_input($input);

--- a/src/parser/state_machine/syntax_dsl/state.rs
+++ b/src/parser/state_machine/syntax_dsl/state.rs
@@ -6,13 +6,14 @@ macro_rules! state {
 
         $($rest:tt)*
     ) => {
-        fn $name(&mut self, input: &[u8]) -> StateResult {
+        #[allow(unused_variables)]
+        fn $name(&mut self, context: &mut Self::Context, input: &[u8]) -> StateResult {
             // NOTE: clippy complains about some states that break the loop in each match arm
             #[allow(clippy::never_loop)]
             loop {
                 let ch = self.consume_ch(input);
 
-                state_body!(|[self, input, ch]|> [$($arms)*], [$($($enter_actions)*)*]);
+                state_body!(|[self, context, input, ch]|> [$($arms)*], [$($($enter_actions)*)*]);
             }
         }
 

--- a/src/parser/state_machine/syntax_dsl/state_body.rs
+++ b/src/parser/state_machine/syntax_dsl/state_body.rs
@@ -1,7 +1,7 @@
 macro_rules! state_body {
-    ( | [ $self:tt, $input:ident, $ch:ident ] |> [$($arms:tt)+], [$($enter_actions:tt)*] ) => {
-        action_list!(@state_enter |$self, $input|> $($enter_actions)*);
-        state_body!(@map_arms | [$self, $input, $ch] |> [$($arms)+], [])
+    ( | [ $self:tt, $ctx:tt, $input:ident, $ch:ident ] |> [$($arms:tt)+], [$($enter_actions:tt)*] ) => {
+        action_list!(@state_enter |$self, $ctx, $input|> $($enter_actions)*);
+        state_body!(@map_arms | [$self, $ctx, $input, $ch] |> [$($arms)+], [])
     };
 
 
@@ -35,7 +35,7 @@ macro_rules! state_body {
     // Character match block
     //--------------------------------------------------------------------
     ( @match_block
-        | [ $self:tt, $input:ident, $ch:ident ] |>
+        | [ $self:tt, $ctx:tt, $input:ident, $ch:ident ] |>
         $( $pat:pat_param $(|$pat_cont:pat)* $(if $pat_expr:expr)* => ( $($actions:tt)* ) )*
     ) => {
         // NOTE: guard against unreachable patterns
@@ -44,7 +44,7 @@ macro_rules! state_body {
         match $ch {
             $(
                 $pat $(| $pat_cont)* $(if $pat_expr)* => {
-                    action_list!(|$self, $input|> $($actions)*);
+                    action_list!(|$self, $ctx, $input|> $($actions)*);
                 }
             )*
         }


### PR DESCRIPTION
We now explicitly pass that state around. This will reduce the number of `Mutex`es in a `Send` version of the rewriter.

Benchmarks show a median speedup of 0.4%... so, no performance difference when all benchmarks are aggregated. 