### PR TITLE
Use internal mutability for `SharedMemoryLimiter`, removing one `RefCell`.

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -168,7 +168,7 @@ cfg_if! {
             EndTag, Serialize, StartTag, Token, TokenCaptureFlags, Mutations
         };
 
-        pub use self::memory::MemoryLimiter;
+        pub use self::memory::SharedMemoryLimiter;
         pub use self::html::{LocalName, LocalNameHash, Tag, Namespace};
     } else {
         mod selectors_vm;

--- a/src/memory/mod.rs
+++ b/src/memory/mod.rs
@@ -4,4 +4,4 @@ mod limiter;
 
 pub use arena::Arena;
 pub use limited_vec::LimitedVec;
-pub use limiter::{MemoryLimitExceededError, MemoryLimiter, SharedMemoryLimiter};
+pub use limiter::{MemoryLimitExceededError, SharedMemoryLimiter};

--- a/src/selectors_vm/mod.rs
+++ b/src/selectors_vm/mod.rs
@@ -549,7 +549,7 @@ mod tests {
     use crate::base::SharedEncoding;
     use crate::errors::RewritingError;
     use crate::html::Namespace;
-    use crate::memory::MemoryLimiter;
+    use crate::memory::SharedMemoryLimiter;
     use crate::rewritable_units::{DocumentEnd, Token, TokenCaptureFlags};
     use crate::rewriter::AsciiCompatibleEncoding;
     use crate::transform_stream::{
@@ -632,7 +632,7 @@ mod tests {
             output_sink: |_: &[u8]| {},
             preallocated_parsing_buffer_size: 0,
             encoding: SharedEncoding::new(AsciiCompatibleEncoding::new(encoding).unwrap()),
-            memory_limiter: MemoryLimiter::new_shared(2048),
+            memory_limiter: SharedMemoryLimiter::new(2048),
             strict: true,
         });
 
@@ -667,7 +667,7 @@ mod tests {
                 ast.add_selector(&selector.parse().unwrap(), i);
             }
 
-            let memory_limiter = MemoryLimiter::new_shared(2048);
+            let memory_limiter = SharedMemoryLimiter::new(2048);
             let enable_esi_tags = false;
             let vm: SelectorMatchingVm<TestElementData> =
                 SelectorMatchingVm::new(ast, UTF_8, memory_limiter, enable_esi_tags);

--- a/src/selectors_vm/stack.rs
+++ b/src/selectors_vm/stack.rs
@@ -315,7 +315,7 @@ impl<E: ElementData> Stack<E> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::memory::MemoryLimiter;
+    use crate::memory::SharedMemoryLimiter;
     use encoding_rs::UTF_8;
 
     #[derive(Default)]
@@ -344,7 +344,7 @@ mod tests {
     #[test]
     #[allow(clippy::reversed_empty_ranges)]
     fn hereditary_jumps_flag() {
-        let mut stack = Stack::new(MemoryLimiter::new_shared(2048), false);
+        let mut stack = Stack::new(SharedMemoryLimiter::new(2048), false);
 
         stack.push_item(item("item1", 0)).unwrap();
 
@@ -372,7 +372,7 @@ mod tests {
     fn pop_up_to() {
         macro_rules! assert_pop_result {
             ($up_to:expr, $expected_unmatched:expr, $expected_items:expr) => {{
-                let mut stack = Stack::new(MemoryLimiter::new_shared(2048), false);
+                let mut stack = Stack::new(SharedMemoryLimiter::new(2048), false);
 
                 stack.push_item(item("html", 0)).unwrap();
                 stack.push_item(item("body", 1)).unwrap();
@@ -414,7 +414,7 @@ mod tests {
 
     #[test]
     fn pop_up_to_on_empty_stack() {
-        let mut stack = Stack::new(MemoryLimiter::new_shared(2048), false);
+        let mut stack = Stack::new(SharedMemoryLimiter::new(2048), false);
         let mut handler_called = false;
 
         stack.pop_up_to(local_name("div"), |_: TestElementData| {

--- a/tests/fixtures/token_capturing.rs
+++ b/tests/fixtures/token_capturing.rs
@@ -4,7 +4,7 @@ use lol_html::errors::RewritingError;
 use lol_html::html_content::{DocumentEnd, TextType};
 use lol_html::test_utils::Output;
 use lol_html::{
-    LocalName, LocalNameHash, MemoryLimiter, Namespace, SharedEncoding, StartTagHandlingResult,
+    LocalName, LocalNameHash, SharedMemoryLimiter, Namespace, SharedEncoding, StartTagHandlingResult,
     Token, TokenCaptureFlags, TransformController, TransformStream, TransformStreamSettings,
 };
 
@@ -96,7 +96,7 @@ pub fn parse(
 
     let mut output = Output::new(encoding.into());
     let transform_controller = TestTransformController::new(token_handler, capture_flags);
-    let memory_limiter = MemoryLimiter::new_shared(2048);
+    let memory_limiter = SharedMemoryLimiter::new(2048);
 
     let mut transform_stream = TransformStream::new(TransformStreamSettings {
         transform_controller,

--- a/tools/parser_trace/src/main.rs
+++ b/tools/parser_trace/src/main.rs
@@ -102,7 +102,7 @@ fn main() {
         transform_controller: TraceTransformController::new(tag_hint_mode),
         output_sink: |_: &[u8]| {},
         preallocated_parsing_buffer_size: 0,
-        memory_limiter: MemoryLimiter::new_shared(2048),
+        memory_limiter: SharedMemoryLimiter::new(2048),
         encoding: SharedEncoding::new(AsciiCompatibleEncoding::new(UTF_8).unwrap()),
         strict: true,
     });


### PR DESCRIPTION
In a `Send` version the `Cell<usize>` can become an `AtomicUsize`.