### PR TITLE
Attribute buffer is no longer shared, removing one `RefCell`.

### DIFF
--- a/src/base/align.rs
+++ b/src/base/align.rs
@@ -2,7 +2,7 @@ pub trait Align {
     fn align(&mut self, offset: usize);
 }
 
-impl<T: Align> Align for Vec<T> {
+impl<T: Align> Align for &mut [T] {
     #[inline]
     fn align(&mut self, offset: usize) {
         for item in self.iter_mut() {

--- a/src/parser/lexer/actions.rs
+++ b/src/parser/lexer/actions.rs
@@ -136,13 +136,11 @@ impl<S: LexemeSink> StateMachineActions for Lexer<S> {
 
     #[inline]
     fn create_start_tag(&mut self, _context: &mut ParserContext<S>, _input: &[u8]) {
-        self.attr_buffer.borrow_mut().clear();
-
         self.current_tag_token = Some(StartTag {
             name: Range::default(),
             name_hash: LocalNameHash::new(),
             ns: Namespace::default(),
-            attributes: Rc::clone(&self.attr_buffer),
+            attributes: Vec::new(),
             self_closing: false,
         });
     }
@@ -314,7 +312,9 @@ impl<S: LexemeSink> StateMachineActions for Lexer<S> {
     #[inline]
     fn finish_attr(&mut self, _context: &mut ParserContext<S>, _input: &[u8]) {
         if let Some(attr) = self.current_attr.take() {
-            self.attr_buffer.borrow_mut().push(attr);
+            if let Some(StartTag { attributes, .. }) = self.current_tag_token.as_mut() {
+                attributes.push(attr);
+            }
         }
     }
 

--- a/src/parser/lexer/lexeme/token_outline.rs
+++ b/src/parser/lexer/lexeme/token_outline.rs
@@ -1,6 +1,6 @@
 use crate::base::{Align, Range};
 use crate::html::{LocalNameHash, Namespace, TextType};
-use crate::parser::SharedAttributeBuffer;
+use crate::parser::AttributeBuffer;
 
 #[derive(Debug, Default, Copy, Clone)]
 pub struct AttributeOutline {
@@ -24,7 +24,7 @@ pub enum TagTokenOutline {
         name: Range,
         name_hash: LocalNameHash,
         ns: Namespace,
-        attributes: SharedAttributeBuffer,
+        attributes: AttributeBuffer,
         self_closing: bool,
     },
 
@@ -57,7 +57,7 @@ impl Align for TagTokenOutline {
                 name, attributes, ..
             } => {
                 name.align(offset);
-                attributes.borrow_mut().align(offset);
+                attributes.as_mut_slice().align(offset);
             }
             TagTokenOutline::EndTag { name, .. } => name.align(offset),
         }

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -7,8 +7,8 @@ mod tree_builder_simulator;
 
 use self::lexer::Lexer;
 pub use self::lexer::{
-    AttributeOutline, Lexeme, LexemeSink, NonTagContentLexeme, NonTagContentTokenOutline,
-    SharedAttributeBuffer, TagLexeme, TagTokenOutline,
+    AttributeBuffer, AttributeOutline, Lexeme, LexemeSink, NonTagContentLexeme,
+    NonTagContentTokenOutline, TagLexeme, TagTokenOutline,
 };
 use self::state_machine::{ActionError, ParsingTermination, StateMachine};
 pub use self::tag_scanner::TagHintSink;

--- a/src/parser/tree_builder_simulator/mod.rs
+++ b/src/parser/tree_builder_simulator/mod.rs
@@ -250,7 +250,7 @@ impl TreeBuilderSimulator {
             // to decide on foreign context exit
             return request_lexeme(|this, lexeme| {
                 expect_tag!(lexeme, StartTag { ref attributes, .. } => {
-                    for attr in attributes.borrow().iter() {
+                    for attr in attributes.iter() {
                         let name = lexeme.part(attr.name);
 
                         if eq_case_insensitive(&name, b"color")
@@ -279,7 +279,7 @@ impl TreeBuilderSimulator {
                     let name = lexeme.part(name);
 
                     if !self_closing && eq_case_insensitive(&name, b"annotation-xml") {
-                        for attr in attributes.borrow().iter() {
+                        for attr in attributes.iter() {
                             let name = lexeme.part(attr.name);
                             let value = lexeme.part(attr.value);
 

--- a/src/rewritable_units/tokens/attributes.rs
+++ b/src/rewritable_units/tokens/attributes.rs
@@ -1,5 +1,5 @@
 use crate::base::Bytes;
-use crate::parser::SharedAttributeBuffer;
+use crate::parser::AttributeBuffer;
 use crate::rewritable_units::Serialize;
 use encoding_rs::Encoding;
 use lazycell::LazyCell;
@@ -139,7 +139,7 @@ impl Debug for Attribute<'_> {
 
 pub struct Attributes<'i> {
     input: &'i Bytes<'i>,
-    attribute_buffer: SharedAttributeBuffer,
+    attribute_buffer: &'i AttributeBuffer,
     items: LazyCell<Vec<Attribute<'i>>>,
     encoding: &'static Encoding,
 }
@@ -147,7 +147,7 @@ pub struct Attributes<'i> {
 impl<'i> Attributes<'i> {
     pub(super) fn new(
         input: &'i Bytes<'i>,
-        attribute_buffer: SharedAttributeBuffer,
+        attribute_buffer: &'i AttributeBuffer,
         encoding: &'static Encoding,
     ) -> Self {
         Attributes {
@@ -196,7 +196,6 @@ impl<'i> Attributes<'i> {
 
     fn init_items(&self) -> Vec<Attribute<'i>> {
         self.attribute_buffer
-            .borrow()
             .iter()
             .map(|a| {
                 Attribute::new(
@@ -227,8 +226,8 @@ impl<'i> Attributes<'i> {
     }
 
     #[cfg(test)]
-    pub fn raw_attributes(&self) -> (&'i Bytes<'i>, SharedAttributeBuffer) {
-        (self.input, std::rc::Rc::clone(&self.attribute_buffer))
+    pub fn raw_attributes(&self) -> (&'i Bytes<'i>, &'i AttributeBuffer) {
+        (self.input, self.attribute_buffer)
     }
 }
 

--- a/src/rewritable_units/tokens/capturer/to_token.rs
+++ b/src/rewritable_units/tokens/capturer/to_token.rs
@@ -2,7 +2,6 @@ use super::*;
 use crate::html::TextType;
 use crate::parser::{NonTagContentLexeme, NonTagContentTokenOutline, TagLexeme, TagTokenOutline};
 use encoding_rs::Encoding;
-use std::rc::Rc;
 
 pub enum ToTokenResult<'i> {
     Token(Box<Token<'i>>),
@@ -44,7 +43,7 @@ impl ToToken for TagLexeme<'_> {
 
                 StartTag::new_token(
                     self.part(name),
-                    Attributes::new(self.input(), Rc::clone(attributes), encoding),
+                    Attributes::new(self.input(), attributes, encoding),
                     ns,
                     self_closing,
                     self.raw(),

--- a/src/rewritable_units/tokens/start_tag.rs
+++ b/src/rewritable_units/tokens/start_tag.rs
@@ -167,7 +167,7 @@ impl<'i> StartTag<'i> {
     }
 
     #[cfg(test)]
-    pub fn raw_attributes(&self) -> (&'i Bytes<'i>, crate::parser::SharedAttributeBuffer) {
+    pub fn raw_attributes(&self) -> (&'i Bytes<'i>, &'i crate::parser::AttributeBuffer) {
         self.attributes.raw_attributes()
     }
 }

--- a/src/selectors_vm/attribute_matcher.rs
+++ b/src/selectors_vm/attribute_matcher.rs
@@ -1,7 +1,7 @@
 use super::compiler::AttrExprOperands;
 use crate::base::Bytes;
 use crate::html::Namespace;
-use crate::parser::{AttributeOutline, SharedAttributeBuffer};
+use crate::parser::{AttributeBuffer, AttributeOutline};
 use encoding_rs::UTF_8;
 use lazy_static::lazy_static;
 use lazycell::LazyCell;
@@ -22,7 +22,7 @@ type MemoizedAttrValue<'i> = LazyCell<Option<Bytes<'i>>>;
 
 pub struct AttributeMatcher<'i> {
     input: &'i Bytes<'i>,
-    attributes: SharedAttributeBuffer,
+    attributes: &'i AttributeBuffer,
     id: MemoizedAttrValue<'i>,
     class: MemoizedAttrValue<'i>,
     is_html_element: bool,
@@ -30,7 +30,7 @@ pub struct AttributeMatcher<'i> {
 
 impl<'i> AttributeMatcher<'i> {
     #[inline]
-    pub fn new(input: &'i Bytes<'i>, attributes: SharedAttributeBuffer, ns: Namespace) -> Self {
+    pub fn new(input: &'i Bytes<'i>, attributes: &'i AttributeBuffer, ns: Namespace) -> Self {
         AttributeMatcher {
             input,
             attributes,
@@ -43,7 +43,6 @@ impl<'i> AttributeMatcher<'i> {
     #[inline]
     fn find(&self, lowercased_name: &Bytes) -> Option<AttributeOutline> {
         self.attributes
-            .borrow()
             .iter()
             .find(|a| {
                 if lowercased_name.len() != a.name.end - a.name.start {

--- a/src/transform_stream/mod.rs
+++ b/src/transform_stream/mod.rs
@@ -3,7 +3,7 @@ mod dispatcher;
 use self::dispatcher::Dispatcher;
 use crate::base::SharedEncoding;
 use crate::memory::{Arena, SharedMemoryLimiter};
-use crate::parser::{Parser, ParserDirective, SharedAttributeBuffer};
+use crate::parser::{Parser, ParserDirective};
 use crate::rewriter::RewritingError;
 
 pub use self::dispatcher::{


### PR DESCRIPTION
~This makes the median benchmark 3.6% slower.~ I'm now not pre-allocating the vector for the attributes and the median benchmark is now only 3.1% slower.