### PR TITLE
Send parameterizable rewriter

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,6 +21,11 @@ include = [
 autotests = false
 edition = "2021"
 
+[lib]
+# Disable libtest to make sure criterion can parse the command line flags.
+# See https://bheisler.github.io/criterion.rs/book/faq.html and https://github.com/rust-lang/rust/issues/47241.
+bench = false
+
 [features]
 debug_trace = []
 integration_test = []
@@ -55,6 +60,7 @@ hashbrown = { version = "0.13.1", features = ["serde"] }
 serde = "1.0.126"
 serde_derive = "1.0.19"
 serde_json = "1.0.65"
+static_assertions = "1.1.0"
 rand = "0.8.5"
 rustc-test = "0.3.1"
 itertools = "0.10.1"

--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
                     Ok(())
                 })
             ],
-            ..Settings::default()
+            ..Settings::new()
         },
         |c: &[u8]| output.extend_from_slice(c)
     );

--- a/benches/cases/parsing.rs
+++ b/benches/cases/parsing.rs
@@ -3,7 +3,7 @@ use lol_html::*;
 define_group!(
     "Parsing",
     [
-        ("Tag scanner", Settings::default()),
+        ("Tag scanner", Settings::new()),
         (
             "Lexer",
             // NOTE: this switches parser to the lexer mode and doesn't
@@ -11,7 +11,7 @@ define_group!(
             // we can get relatively fair comparison.
             Settings {
                 document_content_handlers: vec![doctype!(noop_handler!())],
-                ..Settings::default()
+                ..Settings::new()
             }
         ),
         (
@@ -23,7 +23,7 @@ define_group!(
             // incoming chunks to produce correct text chunk rewritable units.
             Settings {
                 document_content_handlers: vec![doc_text!(noop_handler!())],
-                ..Settings::default()
+                ..Settings::new()
             }
         )
     ]

--- a/benches/cases/rewriting.rs
+++ b/benches/cases/rewriting.rs
@@ -13,7 +13,7 @@ define_group!(
 
                     Ok(())
                 })],
-                ..Settings::default()
+                ..Settings::new()
             }
         ),
         (
@@ -24,7 +24,7 @@ define_group!(
 
                     Ok(())
                 })],
-                ..Settings::default()
+                ..Settings::new()
             }
         )
     ]

--- a/benches/cases/selector_matching.rs
+++ b/benches/cases/selector_matching.rs
@@ -7,28 +7,28 @@ define_group!(
             "Match-all selector",
             Settings {
                 element_content_handlers: vec![element!("*", noop_handler!())],
-                ..Settings::default()
+                ..Settings::new()
             }
         ),
         (
             "Tag name selector",
             Settings {
                 element_content_handlers: vec![element!("div", noop_handler!())],
-                ..Settings::default()
+                ..Settings::new()
             }
         ),
         (
             "Class selector",
             Settings {
                 element_content_handlers: vec![element!(".note", noop_handler!())],
-                ..Settings::default()
+                ..Settings::new()
             }
         ),
         (
             "Attribute selector",
             Settings {
                 element_content_handlers: vec![element!("[href]", noop_handler!())],
-                ..Settings::default()
+                ..Settings::new()
             }
         ),
         (
@@ -43,7 +43,7 @@ define_group!(
                     element!("div img", noop_handler!()),
                     element!("div.note span", noop_handler!())
                 ],
-                ..Settings::default()
+                ..Settings::new()
             }
         )
     ]

--- a/c-api/src/rewriter_builder.rs
+++ b/c-api/src/rewriter_builder.rs
@@ -26,7 +26,7 @@ impl<F> ExternHandler<F> {
 }
 
 macro_rules! add_handler {
-    ($handlers:ident, $self:ident.$ty:ident) => {{
+    ($handlers:ident, $el_ty:ident, $self:ident.$ty:ident) => {{
         if let Some(handler) = $self.$ty.func {
             // NOTE: the closure actually holds a reference to the content
             // handler object, but since we pass the object to the C side this
@@ -41,7 +41,7 @@ macro_rules! add_handler {
 
             $handlers =
                 $handlers.$ty(
-                    move |arg: &mut _| match unsafe { handler(arg, user_data) } {
+                    move |arg: &mut $el_ty| match unsafe { handler(arg, user_data) } {
                         RewriterDirective::Continue => Ok(()),
                         RewriterDirective::Stop => Err("The rewriter has been stopped.".into()),
                     },
@@ -61,10 +61,10 @@ impl ExternDocumentContentHandlers {
     pub fn as_safe_document_content_handlers(&self) -> DocumentContentHandlers {
         let mut handlers = DocumentContentHandlers::default();
 
-        add_handler!(handlers, self.doctype);
-        add_handler!(handlers, self.comments);
-        add_handler!(handlers, self.text);
-        add_handler!(handlers, self.end);
+        add_handler!(handlers, Doctype, self.doctype);
+        add_handler!(handlers, Comment, self.comments);
+        add_handler!(handlers, TextChunk, self.text);
+        add_handler!(handlers, DocumentEnd, self.end);
 
         handlers
     }
@@ -80,9 +80,9 @@ impl ExternElementContentHandlers {
     pub fn as_safe_element_content_handlers(&self) -> ElementContentHandlers {
         let mut handlers = ElementContentHandlers::default();
 
-        add_handler!(handlers, self.element);
-        add_handler!(handlers, self.comments);
-        add_handler!(handlers, self.text);
+        add_handler!(handlers, Element, self.element);
+        add_handler!(handlers, Comment, self.comments);
+        add_handler!(handlers, TextChunk, self.text);
 
         handlers
     }

--- a/examples/defer_scripts/main.rs
+++ b/examples/defer_scripts/main.rs
@@ -21,7 +21,7 @@ fn main() {
                     Ok(())
                 }
             )],
-            ..Settings::default()
+            ..Settings::new()
         },
         output_sink,
     );

--- a/examples/mixed_content_rewriter/main.rs
+++ b/examples/mixed_content_rewriter/main.rs
@@ -37,7 +37,7 @@ fn main() {
                     }
                 ),
             ],
-            ..Settings::default()
+            ..Settings::new()
         },
         output_sink,
     );

--- a/fuzz/test_case/src/lib.rs
+++ b/fuzz/test_case/src/lib.rs
@@ -14,9 +14,7 @@ use std::ffi::{CStr, CString};
 
 use encoding_rs::*;
 use lol_html::html_content::ContentType;
-use lol_html::{
-    comments, doc_comments, doc_text, element, text, HtmlRewriter, MemorySettings, Settings,
-};
+use lol_html::{comments, doc_comments, doc_text, element, text, HtmlRewriter, MemorySettings, Settings};
 
 include!(concat!(env!("OUT_DIR"), "/bindings.rs"));
 
@@ -103,7 +101,7 @@ fn get_random_selector() -> &'static str {
 }
 
 fn run_rewriter_iter(data: &[u8], selector: &str, encoding: &'static Encoding) -> () {
-    let mut rewriter = HtmlRewriter::new(
+    let mut rewriter: HtmlRewriter<_> = HtmlRewriter::new(
         Settings {
             enable_esi_tags: true,
             element_content_handlers: vec![
@@ -178,7 +176,7 @@ fn run_rewriter_iter(data: &[u8], selector: &str, encoding: &'static Encoding) -
                 }),
             ],
             encoding: encoding.try_into().unwrap(),
-            memory_settings: MemorySettings::default(),
+            memory_settings: MemorySettings::new(),
             strict: false,
             adjust_charset_on_meta_tag: false,
         },

--- a/src/base/encoding.rs
+++ b/src/base/encoding.rs
@@ -1,8 +1,249 @@
 use crate::rewriter::AsciiCompatibleEncoding;
 use encoding_rs::Encoding;
-use std::cell::Cell;
-use std::ops::Deref;
-use std::rc::Rc;
+use std::sync::atomic::{AtomicUsize, Ordering};
+use std::sync::Arc;
+
+/// This serves as a map from integer to [`Encoding`], which allows more efficient
+/// sets/gets of the [SharedEncoding].
+static ALL_ENCODINGS: [&Encoding; 228] = [
+    &encoding_rs::WINDOWS_1252_INIT,
+    &encoding_rs::ISO_8859_2_INIT,
+    &encoding_rs::ISO_8859_3_INIT,
+    &encoding_rs::ISO_8859_4_INIT,
+    &encoding_rs::WINDOWS_1254_INIT,
+    &encoding_rs::ISO_8859_10_INIT,
+    &encoding_rs::ISO_8859_15_INIT,
+    &encoding_rs::IBM866_INIT,
+    &encoding_rs::MACINTOSH_INIT,
+    &encoding_rs::KOI8_R_INIT,
+    &encoding_rs::GBK_INIT,
+    &encoding_rs::BIG5_INIT,
+    &encoding_rs::UTF_8_INIT,
+    &encoding_rs::KOI8_R_INIT,
+    &encoding_rs::SHIFT_JIS_INIT,
+    &encoding_rs::UTF_16LE_INIT,
+    &encoding_rs::SHIFT_JIS_INIT,
+    &encoding_rs::IBM866_INIT,
+    &encoding_rs::UTF_8_INIT,
+    &encoding_rs::WINDOWS_1252_INIT,
+    &encoding_rs::WINDOWS_1252_INIT,
+    &encoding_rs::GBK_INIT,
+    &encoding_rs::ISO_8859_7_INIT,
+    &encoding_rs::WINDOWS_1250_INIT,
+    &encoding_rs::WINDOWS_1251_INIT,
+    &encoding_rs::WINDOWS_1252_INIT,
+    &encoding_rs::GBK_INIT,
+    &encoding_rs::WINDOWS_1252_INIT,
+    &encoding_rs::ISO_8859_2_INIT,
+    &encoding_rs::WINDOWS_1253_INIT,
+    &encoding_rs::ISO_8859_3_INIT,
+    &encoding_rs::WINDOWS_1254_INIT,
+    &encoding_rs::ISO_8859_4_INIT,
+    &encoding_rs::WINDOWS_1255_INIT,
+    &encoding_rs::BIG5_INIT,
+    &encoding_rs::WINDOWS_1254_INIT,
+    &encoding_rs::UTF_16LE_INIT,
+    &encoding_rs::WINDOWS_1256_INIT,
+    &encoding_rs::IBM866_INIT,
+    &encoding_rs::ISO_8859_10_INIT,
+    &encoding_rs::WINDOWS_1257_INIT,
+    &encoding_rs::WINDOWS_1258_INIT,
+    &encoding_rs::ISO_8859_7_INIT,
+    &encoding_rs::WINDOWS_1252_INIT,
+    &encoding_rs::ISO_8859_6_INIT,
+    &encoding_rs::ISO_8859_8_INIT,
+    &encoding_rs::EUC_KR_INIT,
+    &encoding_rs::EUC_JP_INIT,
+    &encoding_rs::KOI8_R_INIT,
+    &encoding_rs::KOI8_R_INIT,
+    &encoding_rs::EUC_KR_INIT,
+    &encoding_rs::SHIFT_JIS_INIT,
+    &encoding_rs::KOI8_U_INIT,
+    &encoding_rs::ISO_8859_8_INIT,
+    &encoding_rs::WINDOWS_874_INIT,
+    &encoding_rs::GB18030_INIT,
+    &encoding_rs::EUC_KR_INIT,
+    &encoding_rs::GBK_INIT,
+    &encoding_rs::WINDOWS_874_INIT,
+    &encoding_rs::BIG5_INIT,
+    &encoding_rs::UTF_16LE_INIT,
+    &encoding_rs::GBK_INIT,
+    &encoding_rs::ISO_8859_8_I_INIT,
+    &encoding_rs::KOI8_R_INIT,
+    &encoding_rs::EUC_KR_INIT,
+    &encoding_rs::KOI8_U_INIT,
+    &encoding_rs::WINDOWS_1250_INIT,
+    &encoding_rs::EUC_KR_INIT,
+    &encoding_rs::WINDOWS_1251_INIT,
+    &encoding_rs::WINDOWS_1252_INIT,
+    &encoding_rs::GBK_INIT,
+    &encoding_rs::WINDOWS_1252_INIT,
+    &encoding_rs::ISO_8859_2_INIT,
+    &encoding_rs::WINDOWS_1253_INIT,
+    &encoding_rs::ISO_8859_3_INIT,
+    &encoding_rs::ISO_8859_6_INIT,
+    &encoding_rs::WINDOWS_1254_INIT,
+    &encoding_rs::ISO_8859_4_INIT,
+    &encoding_rs::WINDOWS_1255_INIT,
+    &encoding_rs::ISO_8859_5_INIT,
+    &encoding_rs::BIG5_INIT,
+    &encoding_rs::WINDOWS_1256_INIT,
+    &encoding_rs::IBM866_INIT,
+    &encoding_rs::ISO_8859_6_INIT,
+    &encoding_rs::WINDOWS_1257_INIT,
+    &encoding_rs::ISO_8859_7_INIT,
+    &encoding_rs::ISO_8859_6_INIT,
+    &encoding_rs::ISO_8859_7_INIT,
+    &encoding_rs::ISO_8859_7_INIT,
+    &encoding_rs::WINDOWS_1258_INIT,
+    &encoding_rs::ISO_8859_8_INIT,
+    &encoding_rs::WINDOWS_1254_INIT,
+    &encoding_rs::ISO_8859_5_INIT,
+    &encoding_rs::UTF_16BE_INIT,
+    &encoding_rs::UTF_16LE_INIT,
+    &encoding_rs::WINDOWS_1252_INIT,
+    &encoding_rs::SHIFT_JIS_INIT,
+    &encoding_rs::EUC_JP_INIT,
+    &encoding_rs::ISO_8859_10_INIT,
+    &encoding_rs::WINDOWS_1252_INIT,
+    &encoding_rs::WINDOWS_874_INIT,
+    &encoding_rs::ISO_8859_2_INIT,
+    &encoding_rs::ISO_8859_3_INIT,
+    &encoding_rs::ISO_8859_13_INIT,
+    &encoding_rs::ISO_8859_4_INIT,
+    &encoding_rs::ISO_8859_14_INIT,
+    &encoding_rs::ISO_8859_5_INIT,
+    &encoding_rs::ISO_8859_15_INIT,
+    &encoding_rs::ISO_8859_6_INIT,
+    &encoding_rs::ISO_8859_7_INIT,
+    &encoding_rs::ISO_8859_8_INIT,
+    &encoding_rs::GBK_INIT,
+    &encoding_rs::WINDOWS_1254_INIT,
+    &encoding_rs::UTF_16LE_INIT,
+    &encoding_rs::MACINTOSH_INIT,
+    &encoding_rs::SHIFT_JIS_INIT,
+    &encoding_rs::SHIFT_JIS_INIT,
+    &encoding_rs::WINDOWS_1252_INIT,
+    &encoding_rs::ISO_8859_10_INIT,
+    &encoding_rs::ISO_8859_4_INIT,
+    &encoding_rs::GBK_INIT,
+    &encoding_rs::WINDOWS_1252_INIT,
+    &encoding_rs::WINDOWS_1252_INIT,
+    &encoding_rs::ISO_8859_2_INIT,
+    &encoding_rs::WINDOWS_874_INIT,
+    &encoding_rs::ISO_8859_2_INIT,
+    &encoding_rs::ISO_8859_2_INIT,
+    &encoding_rs::REPLACEMENT_INIT,
+    &encoding_rs::ISO_8859_3_INIT,
+    &encoding_rs::ISO_8859_3_INIT,
+    &encoding_rs::ISO_8859_13_INIT,
+    &encoding_rs::ISO_8859_4_INIT,
+    &encoding_rs::ISO_8859_4_INIT,
+    &encoding_rs::ISO_8859_14_INIT,
+    &encoding_rs::ISO_8859_5_INIT,
+    &encoding_rs::ISO_8859_5_INIT,
+    &encoding_rs::ISO_8859_5_INIT,
+    &encoding_rs::ISO_8859_15_INIT,
+    &encoding_rs::ISO_8859_6_INIT,
+    &encoding_rs::ISO_8859_6_INIT,
+    &encoding_rs::ISO_8859_7_INIT,
+    &encoding_rs::ISO_8859_7_INIT,
+    &encoding_rs::ISO_8859_7_INIT,
+    &encoding_rs::ISO_8859_6_INIT,
+    &encoding_rs::ISO_8859_10_INIT,
+    &encoding_rs::ISO_8859_8_INIT,
+    &encoding_rs::ISO_8859_8_INIT,
+    &encoding_rs::ISO_8859_8_INIT,
+    &encoding_rs::WINDOWS_1254_INIT,
+    &encoding_rs::WINDOWS_1254_INIT,
+    &encoding_rs::WINDOWS_1254_INIT,
+    &encoding_rs::ISO_8859_3_INIT,
+    &encoding_rs::EUC_KR_INIT,
+    &encoding_rs::BIG5_INIT,
+    &encoding_rs::SHIFT_JIS_INIT,
+    &encoding_rs::ISO_8859_10_INIT,
+    &encoding_rs::WINDOWS_874_INIT,
+    &encoding_rs::WINDOWS_1252_INIT,
+    &encoding_rs::ISO_8859_2_INIT,
+    &encoding_rs::ISO_8859_13_INIT,
+    &encoding_rs::ISO_8859_3_INIT,
+    &encoding_rs::ISO_8859_14_INIT,
+    &encoding_rs::WINDOWS_874_INIT,
+    &encoding_rs::ISO_8859_4_INIT,
+    &encoding_rs::ISO_8859_15_INIT,
+    &encoding_rs::ISO_8859_15_INIT,
+    &encoding_rs::WINDOWS_1254_INIT,
+    &encoding_rs::ISO_8859_16_INIT,
+    &encoding_rs::ISO_8859_10_INIT,
+    &encoding_rs::EUC_KR_INIT,
+    &encoding_rs::ISO_8859_15_INIT,
+    &encoding_rs::ISO_8859_6_INIT,
+    &encoding_rs::ISO_8859_8_INIT,
+    &encoding_rs::UTF_16BE_INIT,
+    &encoding_rs::UTF_16LE_INIT,
+    &encoding_rs::MACINTOSH_INIT,
+    &encoding_rs::ISO_8859_6_INIT,
+    &encoding_rs::ISO_8859_8_I_INIT,
+    &encoding_rs::SHIFT_JIS_INIT,
+    &encoding_rs::MACINTOSH_INIT,
+    &encoding_rs::REPLACEMENT_INIT,
+    &encoding_rs::ISO_2022_JP_INIT,
+    &encoding_rs::ISO_2022_JP_INIT,
+    &encoding_rs::REPLACEMENT_INIT,
+    &encoding_rs::REPLACEMENT_INIT,
+    &encoding_rs::REPLACEMENT_INIT,
+    &encoding_rs::WINDOWS_1250_INIT,
+    &encoding_rs::WINDOWS_1251_INIT,
+    &encoding_rs::WINDOWS_1252_INIT,
+    &encoding_rs::WINDOWS_1253_INIT,
+    &encoding_rs::WINDOWS_1254_INIT,
+    &encoding_rs::WINDOWS_1255_INIT,
+    &encoding_rs::WINDOWS_1256_INIT,
+    &encoding_rs::WINDOWS_1257_INIT,
+    &encoding_rs::WINDOWS_1258_INIT,
+    &encoding_rs::ISO_8859_6_INIT,
+    &encoding_rs::ISO_8859_8_INIT,
+    &encoding_rs::ISO_8859_6_INIT,
+    &encoding_rs::ISO_8859_8_I_INIT,
+    &encoding_rs::ISO_8859_7_INIT,
+    &encoding_rs::EUC_KR_INIT,
+    &encoding_rs::UTF_8_INIT,
+    &encoding_rs::UTF_8_INIT,
+    &encoding_rs::EUC_KR_INIT,
+    &encoding_rs::WINDOWS_1252_INIT,
+    &encoding_rs::EUC_KR_INIT,
+    &encoding_rs::X_MAC_CYRILLIC_INIT,
+    &encoding_rs::X_USER_DEFINED_INIT,
+    &encoding_rs::GBK_INIT,
+    &encoding_rs::UTF_16LE_INIT,
+    &encoding_rs::WINDOWS_1252_INIT,
+    &encoding_rs::ISO_8859_2_INIT,
+    &encoding_rs::ISO_8859_6_INIT,
+    &encoding_rs::ISO_8859_7_INIT,
+    &encoding_rs::ISO_8859_3_INIT,
+    &encoding_rs::ISO_8859_4_INIT,
+    &encoding_rs::ISO_8859_5_INIT,
+    &encoding_rs::ISO_8859_8_INIT,
+    &encoding_rs::UTF_8_INIT,
+    &encoding_rs::WINDOWS_1254_INIT,
+    &encoding_rs::ISO_8859_7_INIT,
+    &encoding_rs::X_MAC_CYRILLIC_INIT,
+    &encoding_rs::REPLACEMENT_INIT,
+    &encoding_rs::ISO_8859_6_INIT,
+    &encoding_rs::ISO_8859_8_INIT,
+    &encoding_rs::UTF_8_INIT,
+    &encoding_rs::ISO_8859_5_INIT,
+    &encoding_rs::EUC_JP_INIT,
+];
+
+fn encoding_to_index(encoding: AsciiCompatibleEncoding) -> usize {
+    let encoding: &'static Encoding = encoding.into();
+
+    ALL_ENCODINGS
+        .iter()
+        .position(|&e| e == encoding)
+        .expect("the ALL_ENCODINGS is not complete and needs to be updated")
+}
 
 /// A charset encoding that can be shared and modified.
 ///
@@ -11,29 +252,42 @@ use std::rc::Rc;
 /// [crate::Settings::adjust_charset_on_meta_tag]).
 #[derive(Clone)]
 pub struct SharedEncoding {
-    encoding: Rc<Cell<AsciiCompatibleEncoding>>,
+    encoding: Arc<AtomicUsize>,
 }
 
 impl SharedEncoding {
     pub fn new(encoding: AsciiCompatibleEncoding) -> SharedEncoding {
         SharedEncoding {
-            encoding: Rc::new(Cell::new(encoding)),
+            encoding: Arc::new(AtomicUsize::new(encoding_to_index(encoding))),
         }
     }
 
     pub fn get(&self) -> &'static Encoding {
-        self.encoding.get().into()
+        let encoding = self.encoding.load(Ordering::Relaxed);
+        ALL_ENCODINGS[encoding]
     }
 
     pub fn set(&self, encoding: AsciiCompatibleEncoding) {
-        self.encoding.set(encoding);
+        self.encoding
+            .store(encoding_to_index(encoding), Ordering::Relaxed);
     }
 }
 
-impl Deref for SharedEncoding {
-    type Target = Encoding;
+#[cfg(test)]
+mod tests {
+    use crate::base::encoding::ALL_ENCODINGS;
+    use crate::base::SharedEncoding;
+    use crate::AsciiCompatibleEncoding;
 
-    fn deref(&self) -> &'static Encoding {
-        self.get()
+    #[test]
+    fn test_encoding_round_trip() {
+        let shared_encoding = SharedEncoding::new(AsciiCompatibleEncoding::utf_8());
+
+        for encoding in ALL_ENCODINGS {
+            if let Some(ascii_compat_encoding) = AsciiCompatibleEncoding::new(encoding) {
+                shared_encoding.set(ascii_compat_encoding);
+                assert_eq!(shared_encoding.get(), encoding);
+            }
+        }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,7 +6,7 @@
 //!
 //! The crate serves as a back-end for the HTML rewriting functionality of [Cloudflare Workers], but
 //! can be used as a standalone library with the convenient API for a wide variety of HTML
-//! rewriting/analyzis tasks.
+//! rewriting/analysis tasks.
 //!
 //! The crate provides two main API entry points:
 //!
@@ -37,11 +37,47 @@ use cfg_if::cfg_if;
 
 pub use self::rewriter::{
     rewrite_str, AsciiCompatibleEncoding, CommentHandler, DoctypeHandler, DocumentContentHandlers,
-    ElementContentHandlers, ElementHandler, EndHandler, EndTagHandler, HandlerResult, HtmlRewriter,
-    MemorySettings, RewriteStrSettings, Settings, TextHandler,
+    ElementContentHandlers, ElementHandler, EndHandler, EndTagHandler, HandlerResult, HandlerTypes,
+    HtmlRewriter, LocalHandlerTypes, MemorySettings, RewriteStrSettings, Settings, TextHandler,
 };
 pub use self::selectors_vm::Selector;
 pub use self::transform_stream::OutputSink;
+
+/// These module contains types to work with [`Send`]able [`HtmlRewriter`](crate::HtmlRewriter)s.
+pub mod send {
+    use crate::rewriter::{
+        CommentHandlerSend, DoctypeHandlerSend, ElementHandlerSend, EndHandlerSend,
+        EndTagHandlerSend, SendHandlerTypes, TextHandlerSend,
+    };
+
+    /// An [`HtmlRewriter`](crate::HtmlRewriter) that implements [`Send`].
+    pub type HtmlRewriter<'h, O> = crate::HtmlRewriter<'h, O, SendHandlerTypes>;
+    /// [`Settings`](crate::Settings) for [`Send`]able [`HtmlRewriter`](crate::HtmlRewriter)s.
+    pub type Settings<'h, 's> = crate::Settings<'h, 's, SendHandlerTypes>;
+    /// [`RewriteStrSettings`](crate::RewriteStrSettings) for [`Send`]able [`HtmlRewriter`](crate::HtmlRewriter)s.
+    pub type RewriteStrSettings<'h, 's> = crate::RewriteStrSettings<'h, 's, SendHandlerTypes>;
+
+    /// [`ElementContentHandlers`](crate::ElementContentHandlers) for [`Send`]able [`HtmlRewriter`](crate::HtmlRewriter)s.
+    pub type ElementContentHandlers<'h> = crate::ElementContentHandlers<'h, SendHandlerTypes>;
+    /// [`DocumentContentHandlers`](crate::DocumentContentHandlers) for [`Send`]able [`HtmlRewriter`](crate::HtmlRewriter)s.
+    pub type DocumentContentHandlers<'h> = crate::DocumentContentHandlers<'h, SendHandlerTypes>;
+
+    /// [`CommentHandler`](crate::CommentHandler) for [`Send`]able [`HtmlRewriter`](crate::HtmlRewriter)s.
+    pub type CommentHandler<'h> = CommentHandlerSend<'h>;
+    /// [`DoctypeHandler`](crate::DoctypeHandler) for [`Send`]able [`HtmlRewriter`](crate::HtmlRewriter)s.
+    pub type DoctypeHandler<'h> = DoctypeHandlerSend<'h>;
+    /// [`ElementHandler`](crate::ElementHandler) for [`Send`]able [`HtmlRewriter`](crate::HtmlRewriter)s.
+    pub type ElementHandler<'h> = ElementHandlerSend<'h>;
+    /// [`EndHandler`](crate::EndHandler) for [`Send`]able [`HtmlRewriter`](crate::HtmlRewriter)s.
+    pub type EndHandler<'h> = EndHandlerSend<'h>;
+    /// [`EndTagHandler`](crate::EndTagHandler) for [`Send`]able [`HtmlRewriter`](crate::HtmlRewriter)s.
+    pub type EndTagHandler<'h> = EndTagHandlerSend<'h>;
+    /// [`TextHandler`](crate::TextHandler) for [`Send`]able [`HtmlRewriter`](crate::HtmlRewriter)s.
+    pub type TextHandler<'h> = TextHandlerSend<'h>;
+
+    /// [`Element`](crate::Element) for [`Send`]able [`HtmlRewriter`](crate::HtmlRewriter)s.
+    pub type Element<'r, 't> = crate::rewritable_units::Element<'r, 't, SendHandlerTypes>;
+}
 
 /// The errors that can be produced by the crate's API.
 pub mod errors {

--- a/src/parser/tree_builder_simulator/mod.rs
+++ b/src/parser/tree_builder_simulator/mod.rs
@@ -28,7 +28,9 @@ pub enum TreeBuilderFeedback {
     SwitchTextType(TextType),
     SetAllowCdata(bool),
     #[allow(clippy::type_complexity)]
-    RequestLexeme(Box<dyn FnMut(&mut TreeBuilderSimulator, &TagLexeme) -> TreeBuilderFeedback>),
+    RequestLexeme(
+        Box<dyn FnMut(&mut TreeBuilderSimulator, &TagLexeme) -> TreeBuilderFeedback + Send>,
+    ),
     None,
 }
 
@@ -41,7 +43,7 @@ impl From<TextType> for TreeBuilderFeedback {
 
 #[inline]
 fn request_lexeme(
-    callback: impl FnMut(&mut TreeBuilderSimulator, &TagLexeme) -> TreeBuilderFeedback + 'static,
+    callback: impl FnMut(&mut TreeBuilderSimulator, &TagLexeme) -> TreeBuilderFeedback + 'static + Send,
 ) -> TreeBuilderFeedback {
     TreeBuilderFeedback::RequestLexeme(Box::new(callback))
 }

--- a/src/rewritable_units/document_end.rs
+++ b/src/rewritable_units/document_end.rs
@@ -40,7 +40,7 @@ impl<'a> DocumentEnd<'a> {
     ///             end.append("<baz>", ContentType::Text);
     ///             Ok(())
     ///         })],
-    ///         ..RewriteStrSettings::default()
+    ///         ..RewriteStrSettings::new()
     ///     }
     /// ).unwrap();
     ///

--- a/src/rewritable_units/mod.rs
+++ b/src/rewritable_units/mod.rs
@@ -44,7 +44,7 @@ pub use self::tokens::*;
 ///                 Ok(())
 ///             })
 ///         ],
-///         ..RewriteStrSettings::default()
+///         ..RewriteStrSettings::new()
 ///     }
 /// ).unwrap();
 /// ```
@@ -115,11 +115,11 @@ mod test_utils {
             .collect()
     }
 
-    pub fn rewrite_html(
+    pub fn rewrite_html<'h>(
         html: &[u8],
         encoding: &'static Encoding,
-        element_content_handlers: Vec<(Cow<'_, Selector>, ElementContentHandlers)>,
-        document_content_handlers: Vec<DocumentContentHandlers>,
+        element_content_handlers: Vec<(Cow<'_, Selector>, ElementContentHandlers<'h>)>,
+        document_content_handlers: Vec<DocumentContentHandlers<'h>>,
     ) -> String {
         let mut output = Output::new(encoding);
 
@@ -129,7 +129,7 @@ mod test_utils {
                     element_content_handlers,
                     document_content_handlers,
                     encoding: AsciiCompatibleEncoding::new(encoding).unwrap(),
-                    ..Settings::default()
+                    ..Settings::new()
                 },
                 |c: &[u8]| output.push(c),
             );

--- a/src/rewritable_units/tokens/comment.rs
+++ b/src/rewritable_units/tokens/comment.rs
@@ -94,7 +94,7 @@ impl<'i> Comment<'i> {
     ///                 Ok(())
     ///             })
     ///         ],
-    ///         ..RewriteStrSettings::default()
+    ///         ..RewriteStrSettings::new()
     ///     }
     /// ).unwrap();
     ///
@@ -126,7 +126,7 @@ impl<'i> Comment<'i> {
     ///                 Ok(())
     ///             })
     ///         ],
-    ///         ..RewriteStrSettings::default()
+    ///         ..RewriteStrSettings::new()
     ///     }
     /// ).unwrap();
     ///
@@ -158,7 +158,7 @@ impl<'i> Comment<'i> {
     ///                 Ok(())
     ///             })
     ///         ],
-    ///         ..RewriteStrSettings::default()
+    ///         ..RewriteStrSettings::new()
     ///     }
     /// ).unwrap();
     ///

--- a/src/rewritable_units/tokens/doctype.rs
+++ b/src/rewritable_units/tokens/doctype.rs
@@ -25,7 +25,7 @@ use std::fmt::{self, Debug};
 ///                 Ok(())
 ///             })
 ///         ],
-///         ..RewriteStrSettings::default()
+///         ..RewriteStrSettings::new()
 ///     }
 /// ).unwrap();
 /// ```

--- a/src/rewritable_units/tokens/text_chunk.rs
+++ b/src/rewritable_units/tokens/text_chunk.rs
@@ -42,7 +42,7 @@ use std::fmt::{self, Debug};
 ///                     Ok(())
 ///                 })
 ///             ],
-///             ..Settings::default()
+///             ..Settings::new()
 ///         },
 ///         |_:&[u8]| {}
 ///     );
@@ -131,7 +131,7 @@ impl<'i> TextChunk<'i> {
     ///                 Ok(())
     ///             })
     ///         ],
-    ///         ..RewriteStrSettings::default()
+    ///         ..RewriteStrSettings::new()
     ///     }
     /// ).unwrap();
     /// ```
@@ -171,7 +171,7 @@ impl<'i> TextChunk<'i> {
     ///                 Ok(())
     ///             })
     ///         ],
-    ///         ..RewriteStrSettings::default()
+    ///         ..RewriteStrSettings::new()
     ///     }
     /// ).unwrap();
     ///
@@ -205,7 +205,7 @@ impl<'i> TextChunk<'i> {
     ///                 Ok(())
     ///             })
     ///         ],
-    ///         ..RewriteStrSettings::default()
+    ///         ..RewriteStrSettings::new()
     ///     }
     /// ).unwrap();
     ///
@@ -239,7 +239,7 @@ impl<'i> TextChunk<'i> {
     ///                 Ok(())
     ///             })
     ///         ],
-    ///         ..RewriteStrSettings::default()
+    ///         ..RewriteStrSettings::new()
     ///     }
     /// ).unwrap();
     ///

--- a/src/rewriter/rewrite_controller.rs
+++ b/src/rewriter/rewrite_controller.rs
@@ -1,5 +1,5 @@
 use super::handlers_dispatcher::{ContentHandlersDispatcher, SelectorHandlersLocator};
-use super::RewritingError;
+use super::{HandlerTypes, RewritingError};
 use crate::html::{LocalName, Namespace};
 use crate::rewritable_units::{DocumentEnd, Token, TokenCaptureFlags};
 use crate::selectors_vm::{AuxStartTagInfoRequest, ElementData, SelectorMatchingVm, VmError};
@@ -22,15 +22,15 @@ impl ElementData for ElementDescriptor {
     }
 }
 
-pub struct HtmlRewriteController<'h> {
-    handlers_dispatcher: ContentHandlersDispatcher<'h>,
+pub struct HtmlRewriteController<'h, H: HandlerTypes> {
+    handlers_dispatcher: ContentHandlersDispatcher<'h, H>,
     selector_matching_vm: Option<SelectorMatchingVm<ElementDescriptor>>,
 }
 
-impl<'h> HtmlRewriteController<'h> {
+impl<'h, H: HandlerTypes> HtmlRewriteController<'h, H> {
     #[inline]
     pub fn new(
-        handlers_dispatcher: ContentHandlersDispatcher<'h>,
+        handlers_dispatcher: ContentHandlersDispatcher<'h, H>,
         selector_matching_vm: Option<SelectorMatchingVm<ElementDescriptor>>,
     ) -> Self {
         HtmlRewriteController {
@@ -40,7 +40,7 @@ impl<'h> HtmlRewriteController<'h> {
     }
 }
 
-impl<'h> HtmlRewriteController<'h> {
+impl<'h, H: HandlerTypes> HtmlRewriteController<'h, H> {
     #[inline]
     fn respond_to_aux_info_request(
         aux_info_req: AuxStartTagInfoRequest<ElementDescriptor, SelectorHandlersLocator>,
@@ -65,7 +65,7 @@ impl<'h> HtmlRewriteController<'h> {
     }
 }
 
-impl TransformController for HtmlRewriteController<'_> {
+impl<'h, H: HandlerTypes> TransformController for HtmlRewriteController<'h, H> {
     #[inline]
     fn initial_capture_flags(&self) -> TokenCaptureFlags {
         self.get_capture_flags()

--- a/src/selectors_vm/compiler.rs
+++ b/src/selectors_vm/compiler.rs
@@ -13,9 +13,9 @@ use std::hash::Hash;
 use std::iter;
 
 /// An expression using only the tag name of an element.
-pub type CompiledLocalNameExpr = Box<dyn Fn(&SelectorState, &LocalName) -> bool>;
+pub type CompiledLocalNameExpr = Box<dyn Fn(&SelectorState, &LocalName) -> bool + Send>;
 /// An expression using the attributes of an element.
-pub type CompiledAttributeExpr = Box<dyn Fn(&SelectorState, &AttributeMatcher) -> bool>;
+pub type CompiledAttributeExpr = Box<dyn Fn(&SelectorState, &AttributeMatcher) -> bool + Send>;
 
 #[derive(Default)]
 struct ExprSet {
@@ -31,7 +31,7 @@ pub struct AttrExprOperands {
 
 impl Expr<OnTagNameExpr> {
     #[inline]
-    pub fn compile_expr<F: Fn(&SelectorState, &LocalName) -> bool + 'static>(
+    pub fn compile_expr<F: Fn(&SelectorState, &LocalName) -> bool + Send + 'static>(
         &self,
         f: F,
     ) -> CompiledLocalNameExpr {
@@ -92,7 +92,7 @@ impl Compilable for Expr<OnTagNameExpr> {
 
 impl Expr<OnAttributesExpr> {
     #[inline]
-    pub fn compile_expr<F: Fn(&SelectorState, &AttributeMatcher) -> bool + 'static>(
+    pub fn compile_expr<F: Fn(&SelectorState, &AttributeMatcher) -> bool + Send + 'static>(
         &self,
         f: F,
     ) -> CompiledAttributeExpr {

--- a/src/selectors_vm/mod.rs
+++ b/src/selectors_vm/mod.rs
@@ -28,10 +28,11 @@ pub struct MatchInfo<P> {
 
 pub type AuxStartTagInfoRequest<E, P> = Box<
     dyn FnOnce(
-        &mut SelectorMatchingVm<E>,
-        AuxStartTagInfo,
-        &mut dyn FnMut(MatchInfo<P>),
-    ) -> Result<(), MemoryLimitExceededError>,
+            &mut SelectorMatchingVm<E>,
+            AuxStartTagInfo,
+            &mut dyn FnMut(MatchInfo<P>),
+        ) -> Result<(), MemoryLimitExceededError>
+        + Send,
 >;
 
 pub enum VmError<E: ElementData, MatchPayload> {
@@ -143,7 +144,10 @@ pub struct SelectorMatchingVm<E: ElementData> {
     enable_esi_tags: bool,
 }
 
-impl<E: ElementData> SelectorMatchingVm<E> {
+impl<E> SelectorMatchingVm<E>
+where
+    E: ElementData + Send,
+{
     #[inline]
     pub fn new(
         ast: Ast<E::MatchPayload>,
@@ -238,7 +242,7 @@ impl<E: ElementData> SelectorMatchingVm<E> {
         Ok(())
     }
 
-    fn bailout<T: 'static>(
+    fn bailout<T: 'static + Send>(
         ctx: ExecutionCtx<E>,
         bailout: Bailout<T>,
         recovery_point_handler: RecoveryPointHandler<T, E, E::MatchPayload>,

--- a/src/transform_stream/dispatcher.rs
+++ b/src/transform_stream/dispatcher.rs
@@ -17,8 +17,9 @@ pub struct AuxStartTagInfo<'i> {
     pub self_closing: bool,
 }
 
-type AuxStartTagInfoRequest<C> =
-    Box<dyn FnOnce(&mut C, AuxStartTagInfo<'_>) -> Result<TokenCaptureFlags, RewritingError>>;
+type AuxStartTagInfoRequest<C> = Box<
+    dyn FnOnce(&mut C, AuxStartTagInfo<'_>) -> Result<TokenCaptureFlags, RewritingError> + Send,
+>;
 
 pub enum DispatcherError<C> {
     InfoRequest(AuxStartTagInfoRequest<C>),

--- a/src/transform_stream/mod.rs
+++ b/src/transform_stream/mod.rs
@@ -1,14 +1,13 @@
 mod dispatcher;
 
 use self::dispatcher::Dispatcher;
+pub use self::dispatcher::{
+    AuxStartTagInfo, DispatcherError, OutputSink, StartTagHandlingResult, TransformController,
+};
 use crate::base::SharedEncoding;
 use crate::memory::{Arena, SharedMemoryLimiter};
 use crate::parser::{Parser, ParserDirective};
 use crate::rewriter::RewritingError;
-
-pub use self::dispatcher::{
-    AuxStartTagInfo, DispatcherError, OutputSink, StartTagHandlingResult, TransformController,
-};
 
 pub struct TransformStreamSettings<C, O>
 where

--- a/tests/fixtures/element_content_replacement.rs
+++ b/tests/fixtures/element_content_replacement.rs
@@ -31,7 +31,7 @@ impl TestFixture<TestCase> for ElementContentReplacementTests {
                         })
                     ],
                     encoding,
-                    ..Settings::default()
+                    ..Settings::new()
                 },
                 |c: &[u8]| output.push(c)
             );

--- a/tests/fixtures/selector_matching.rs
+++ b/tests/fixtures/selector_matching.rs
@@ -68,7 +68,7 @@ impl TestFixture<TestCase> for SelectorMatchingTests {
                         })
                     ],
                     encoding,
-                    ..Settings::default()
+                    ..Settings::new()
                 },
                 |c: &[u8]| output.push(c)
             );

--- a/tests/harness/suites/html5lib_tests/decoder.rs
+++ b/tests/harness/suites/html5lib_tests/decoder.rs
@@ -91,10 +91,8 @@ impl<'a> Decoder<'a> {
                 self.chars.next();
                 if m.0 != 0 {
                     if c != ';' && self.entities == Entities::Attribute {
-                        if let Some(&c) = self.chars.peek() {
-                            if matches!(c, 'A'..='Z' | 'a'..='z' | '0'..='9' | '=') {
-                                continue;
-                            }
+                        if let Some('A'..='Z' | 'a'..='z' | '0'..='9' | '=') = self.chars.peek() {
+                            continue;
                         }
                     }
                     name_match = (m.0, m.1, name_buf.len());


### PR DESCRIPTION
Some data structures had to be turned into `Sync` to make the rewriter `Send` (if the handlers are `Send`). This has a performance penalty even when using a non-`Send` rewriter. 

The benchmarks have a median slowdown of  -0.8%. You read that right: a negative slowdown, which is a speedup. This  can only be explained by noise while running the benchmarks, as they can only get slightly slower, not faster. However, it shows that the performance change is negligible (in my x86 machine, at least).