### PR TITLE
Release v2.0.0.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,12 @@
 # Changelog
 
+## v2.0.0
+
+- Added the ability for the rewriter to be [`Send`](https://doc.rust-lang.org/std/marker/trait.Send.html).
+  The `send` module contains the utilities for that.
+
 ## v1.2.1
+
 - Remove unmaintained `safemem` dependency.
 
 ## v1.2.0

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "lol_html"
-version = "1.2.1"
+version = "2.0.0"
 authors = ["Ivan Nikulin <inikulin@cloudflare.com, ifaaan@gmail.com>"]
 license = "BSD-3-Clause"
 description = "Streaming HTML rewriter/parser with CSS selector-based API"


### PR DESCRIPTION
- Added the ability for the rewriter to be [`Send`](https://doc.rust-lang.org/std/marker/trait.Send.html). The `send` module contains the utilities for that.