### PR TITLE
Limit visibility where possible

### DIFF
--- a/src/base/align.rs
+++ b/src/base/align.rs
@@ -1,4 +1,4 @@
-pub trait Align {
+pub(crate) trait Align {
     fn align(&mut self, offset: usize);
 }
 

--- a/src/base/encoding.rs
+++ b/src/base/encoding.rs
@@ -250,6 +250,7 @@ fn encoding_to_index(encoding: AsciiCompatibleEncoding) -> usize {
 /// This is, for instance, used to adapt the charset dynamically in a [`crate::HtmlRewriter`] if it
 /// encounters a `meta` tag that specifies the charset (that behavior is dependent on
 /// [`crate::Settings::adjust_charset_on_meta_tag`]).
+// Pub only for integration tests
 #[derive(Clone)]
 pub struct SharedEncoding {
     encoding: Arc<AtomicUsize>,

--- a/src/base/mod.rs
+++ b/src/base/mod.rs
@@ -6,7 +6,7 @@ mod bytes;
 mod encoding;
 mod range;
 
-pub use self::align::Align;
-pub use self::bytes::{Bytes, HasReplacementsError};
+pub(crate) use self::align::Align;
+pub(crate) use self::bytes::{Bytes, HasReplacementsError};
 pub use self::encoding::SharedEncoding;
-pub use self::range::Range;
+pub(crate) use self::range::Range;

--- a/src/base/range.rs
+++ b/src/base/range.rs
@@ -3,7 +3,7 @@ use super::Align;
 // NOTE: std::ops::Range implements iterator and, thus, doesn't implement Copy.
 // See: https://github.com/rust-lang/rust/pull/27186
 #[derive(Clone, Copy, Default, Debug)]
-pub struct Range {
+pub(crate) struct Range {
     pub start: usize,
     pub end: usize,
 }

--- a/src/html/local_name.rs
+++ b/src/html/local_name.rs
@@ -25,6 +25,8 @@ use encoding_rs::Encoding;
 // for digits, but considering that tag name can't start with a digit
 // we are safe here, since we'll just get first character shifted left
 // by zeroes as repetitave 1 digits get added to the hash.
+//
+// Pub only for integration tests
 #[derive(Debug, PartialEq, Eq, Copy, Clone, Default, Hash)]
 pub struct LocalNameHash(Option<u64>);
 
@@ -109,7 +111,7 @@ pub enum LocalName<'i> {
 impl<'i> LocalName<'i> {
     #[inline]
     #[must_use]
-    pub fn new(input: &'i Bytes<'i>, range: Range, hash: LocalNameHash) -> Self {
+    pub(crate) fn new(input: &'i Bytes<'i>, range: Range, hash: LocalNameHash) -> Self {
         if hash.is_empty() {
             LocalName::Bytes(input.slice(range))
         } else {

--- a/src/html/mod.rs
+++ b/src/html/mod.rs
@@ -7,5 +7,5 @@ mod text_type;
 
 pub use self::local_name::{LocalName, LocalNameHash};
 pub use self::namespace::Namespace;
-pub use self::tag::*;
+pub use self::tag::Tag;
 pub use self::text_type::TextType;

--- a/src/html/namespace.rs
+++ b/src/html/namespace.rs
@@ -1,3 +1,4 @@
+// Pub only for integration tests
 #[derive(Default, Copy, Clone, Eq, PartialEq, Debug)]
 pub enum Namespace {
     #[default]

--- a/src/html/tag.rs
+++ b/src/html/tag.rs
@@ -1,5 +1,6 @@
 macro_rules! declare_tags {
     ($($name:ident = $val:expr),+) => {
+        // Pub only for integration tests
         #[repr(u64)]
         #[derive(Debug, Copy, Clone)]
         pub enum Tag {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -18,6 +18,7 @@
 //! [`rewrite_str`]: fn.rewrite_str.html
 #![allow(clippy::default_trait_access)]
 #![allow(clippy::module_name_repetitions)]
+#![allow(clippy::redundant_pub_crate)]
 #![cfg_attr(not(any(feature = "integration_test", test)), warn(missing_docs))]
 #![cfg_attr(any(feature = "integration_test", test), allow(unnameable_types))]
 

--- a/src/memory/arena.rs
+++ b/src/memory/arena.rs
@@ -3,7 +3,7 @@ use super::{MemoryLimitExceededError, SharedMemoryLimiter};
 /// Preallocated region of memory that can grow and never deallocates during the lifetime of
 /// the limiter.
 #[derive(Debug)]
-pub struct Arena {
+pub(crate) struct Arena {
     limiter: SharedMemoryLimiter,
     data: Vec<u8>,
 }

--- a/src/memory/limited_vec.rs
+++ b/src/memory/limited_vec.rs
@@ -7,7 +7,7 @@ use std::vec::Drain;
 use super::{MemoryLimitExceededError, SharedMemoryLimiter};
 
 #[derive(Debug)]
-pub struct LimitedVec<T> {
+pub(crate) struct LimitedVec<T> {
     limiter: SharedMemoryLimiter,
     vec: Vec<T>,
 }

--- a/src/memory/limiter.rs
+++ b/src/memory/limiter.rs
@@ -10,6 +10,7 @@ use thiserror::Error;
 #[error("The memory limit has been exceeded.")]
 pub struct MemoryLimitExceededError;
 
+// Pub only for integration tests
 #[derive(Debug, Clone)]
 pub struct SharedMemoryLimiter {
     current_usage: Arc<AtomicUsize>,

--- a/src/memory/mod.rs
+++ b/src/memory/mod.rs
@@ -2,6 +2,6 @@ mod arena;
 mod limited_vec;
 mod limiter;
 
-pub use arena::Arena;
-pub use limited_vec::LimitedVec;
+pub(crate) use arena::Arena;
+pub(crate) use limited_vec::LimitedVec;
 pub use limiter::{MemoryLimitExceededError, SharedMemoryLimiter};

--- a/src/parser/lexer/lexeme/mod.rs
+++ b/src/parser/lexer/lexeme/mod.rs
@@ -3,9 +3,9 @@ mod token_outline;
 use crate::base::{Bytes, Range};
 use std::fmt::{self, Debug};
 
-pub use self::token_outline::*;
+pub(crate) use self::token_outline::*;
 
-pub struct Lexeme<'i, T> {
+pub(crate) struct Lexeme<'i, T> {
     input: Bytes<'i>,
     raw_range: Range,
     pub(super) token_outline: T,
@@ -15,7 +15,7 @@ pub type TagLexeme<'i> = Lexeme<'i, TagTokenOutline>;
 pub type NonTagContentLexeme<'i> = Lexeme<'i, Option<NonTagContentTokenOutline>>;
 
 impl<'i, T> Lexeme<'i, T> {
-    pub fn new(input: Bytes<'i>, token_outline: T, raw_range: Range) -> Self {
+    pub const fn new(input: Bytes<'i>, token_outline: T, raw_range: Range) -> Self {
         Lexeme {
             input,
             raw_range,
@@ -24,17 +24,17 @@ impl<'i, T> Lexeme<'i, T> {
     }
 
     #[inline]
-    pub fn input(&self) -> &Bytes<'i> {
+    pub const fn input(&self) -> &Bytes<'i> {
         &self.input
     }
 
     #[inline]
-    pub fn token_outline(&self) -> &T {
+    pub const fn token_outline(&self) -> &T {
         &self.token_outline
     }
 
     #[inline]
-    pub fn raw_range(&self) -> Range {
+    pub const fn raw_range(&self) -> Range {
         self.raw_range
     }
 

--- a/src/parser/lexer/lexeme/token_outline.rs
+++ b/src/parser/lexer/lexeme/token_outline.rs
@@ -3,7 +3,7 @@ use crate::html::{LocalNameHash, Namespace, TextType};
 use crate::parser::AttributeBuffer;
 
 #[derive(Debug, Default, Copy, Clone)]
-pub struct AttributeOutline {
+pub(crate) struct AttributeOutline {
     pub name: Range,
     pub value: Range,
     pub raw_range: Range,
@@ -19,7 +19,7 @@ impl Align for AttributeOutline {
 }
 
 #[derive(Debug)]
-pub enum TagTokenOutline {
+pub(crate) enum TagTokenOutline {
     StartTag {
         name: Range,
         name_hash: LocalNameHash,
@@ -35,7 +35,7 @@ pub enum TagTokenOutline {
 }
 
 #[derive(Debug)]
-pub enum NonTagContentTokenOutline {
+pub(crate) enum NonTagContentTokenOutline {
     Text(TextType),
     Comment(Range),
 

--- a/src/parser/lexer/mod.rs
+++ b/src/parser/lexer/mod.rs
@@ -4,7 +4,7 @@ mod actions;
 mod conditions;
 mod lexeme;
 
-pub use self::lexeme::*;
+pub(crate) use self::lexeme::*;
 use crate::base::{Align, Range};
 use crate::html::{LocalNameHash, Namespace, TextType};
 use crate::parser::state_machine::{
@@ -13,7 +13,7 @@ use crate::parser::state_machine::{
 use crate::parser::{ParserContext, ParserDirective, ParsingAmbiguityError, TreeBuilderFeedback};
 use crate::rewriter::RewritingError;
 
-pub trait LexemeSink {
+pub(crate) trait LexemeSink {
     fn handle_tag(&mut self, lexeme: &TagLexeme<'_>) -> Result<ParserDirective, RewritingError>;
     fn handle_non_tag_content(
         &mut self,
@@ -21,11 +21,11 @@ pub trait LexemeSink {
     ) -> Result<(), RewritingError>;
 }
 
-pub type State<S> = fn(&mut Lexer<S>, context: &mut ParserContext<S>, &[u8]) -> StateResult;
+pub(crate) type State<S> = fn(&mut Lexer<S>, context: &mut ParserContext<S>, &[u8]) -> StateResult;
 
-pub type AttributeBuffer = Vec<AttributeOutline>;
+pub(crate) type AttributeBuffer = Vec<AttributeOutline>;
 
-pub struct Lexer<S: LexemeSink> {
+pub(crate) struct Lexer<S> {
     next_pos: usize,
     is_last_input: bool,
     lexeme_start: usize,

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -6,12 +6,12 @@ mod tag_scanner;
 mod tree_builder_simulator;
 
 use self::lexer::Lexer;
-pub use self::lexer::{
+pub(crate) use self::lexer::{
     AttributeBuffer, AttributeOutline, Lexeme, LexemeSink, NonTagContentLexeme,
     NonTagContentTokenOutline, TagLexeme, TagTokenOutline,
 };
 use self::state_machine::{ActionError, ParsingTermination, StateMachine};
-pub use self::tag_scanner::TagHintSink;
+pub(crate) use self::tag_scanner::TagHintSink;
 use self::tag_scanner::TagScanner;
 pub use self::tree_builder_simulator::ParsingAmbiguityError;
 use self::tree_builder_simulator::{TreeBuilderFeedback, TreeBuilderSimulator};
@@ -23,25 +23,28 @@ use cfg_if::cfg_if;
 // to consumer to switch the parser back to the tag scan mode in
 // the tag handler.
 #[derive(Clone, Copy, Debug)]
-pub enum ParserDirective {
+pub(crate) enum ParserDirective {
     WherePossibleScanForTagsOnly,
     Lex,
 }
 
-pub struct ParserContext<S> {
+pub(crate) struct ParserContext<S> {
     output_sink: S,
     tree_builder_simulator: TreeBuilderSimulator,
 }
 
-pub trait ParserOutputSink: LexemeSink + TagHintSink {}
+pub(crate) trait ParserOutputSink: LexemeSink + TagHintSink {}
 
-pub struct Parser<S: ParserOutputSink> {
+// Pub only for integration tests
+pub struct Parser<S> {
     lexer: Lexer<S>,
     tag_scanner: TagScanner<S>,
     current_directive: ParserDirective,
     context: ParserContext<S>,
 }
 
+// public only for integration tests
+#[allow(private_bounds, private_interfaces)]
 impl<S: ParserOutputSink> Parser<S> {
     #[inline]
     #[must_use]
@@ -112,6 +115,7 @@ cfg_if! {
     if #[cfg(feature = "integration_test")] {
         use crate::html::{LocalNameHash, TextType};
 
+        #[allow(private_bounds)]
         impl<S: ParserOutputSink> Parser<S> {
             pub fn switch_text_type(&mut self, text_type: TextType) {
                 match self.current_directive {

--- a/src/parser/state_machine/mod.rs
+++ b/src/parser/state_machine/mod.rs
@@ -10,7 +10,7 @@ use crate::rewriter::RewritingError;
 use std::fmt::{self, Debug};
 use std::mem;
 
-pub enum FeedbackDirective {
+pub(crate) enum FeedbackDirective {
     ApplyUnhandledFeedback(TreeBuilderFeedback),
     Skip,
     None,
@@ -39,7 +39,7 @@ impl Debug for FeedbackDirective {
 }
 
 #[derive(Debug)]
-pub struct StateMachineBookmark {
+pub(crate) struct StateMachineBookmark {
     cdata_allowed: bool,
     text_type: TextType,
     last_start_tag_name_hash: LocalNameHash,
@@ -48,7 +48,7 @@ pub struct StateMachineBookmark {
     feedback_directive: FeedbackDirective,
 }
 
-pub enum ActionError {
+pub(crate) enum ActionError {
     RewritingError(RewritingError),
     ParserDirectiveChangeRequired(ParserDirective, StateMachineBookmark),
 }
@@ -72,7 +72,7 @@ pub type ActionResult = Result<(), ActionError>;
 pub type StateResult = Result<(), ParsingTermination>;
 pub type ParseResult = Result<Never, ParsingTermination>;
 
-pub trait StateMachineActions {
+pub(crate) trait StateMachineActions {
     type Context;
 
     fn emit_eof(&mut self, context: &mut Self::Context, input: &[u8]) -> ActionResult;
@@ -131,12 +131,12 @@ pub trait StateMachineActions {
     fn leave_cdata(&mut self, context: &mut Self::Context, input: &[u8]);
 }
 
-pub trait StateMachineConditions {
+pub(crate) trait StateMachineConditions {
     fn is_appropriate_end_tag(&self) -> bool;
     fn cdata_allowed(&self) -> bool;
 }
 
-pub trait StateMachine: StateMachineActions + StateMachineConditions {
+pub(crate) trait StateMachine: StateMachineActions + StateMachineConditions {
     cdata_section_states_group!();
     data_states_group!();
     plaintext_states_group!();

--- a/src/parser/tag_scanner/mod.rs
+++ b/src/parser/tag_scanner/mod.rs
@@ -9,7 +9,7 @@ use crate::parser::{ParserContext, ParserDirective, ParsingAmbiguityError, TreeB
 use crate::rewriter::RewritingError;
 use std::cmp::min;
 
-pub trait TagHintSink {
+pub(crate) trait TagHintSink {
     fn handle_start_tag_hint(
         &mut self,
         name: LocalName<'_>,
@@ -21,7 +21,8 @@ pub trait TagHintSink {
     ) -> Result<ParserDirective, RewritingError>;
 }
 
-pub type State<S> = fn(&mut TagScanner<S>, context: &mut ParserContext<S>, &[u8]) -> StateResult;
+pub(crate) type State<S> =
+    fn(&mut TagScanner<S>, context: &mut ParserContext<S>, &[u8]) -> StateResult;
 
 /// Tag scanner skips the majority of lexer operations and, thus,
 /// is faster. It also has much less requirements for buffering which makes it more
@@ -34,7 +35,7 @@ pub type State<S> = fn(&mut TagScanner<S>, context: &mut ParserContext<S>, &[u8]
 /// of the input (e.g. `<div` will produce a tag preview, but not tag token). However,
 /// it's not a concern for our use case as no content will be erroneously captured
 /// in this case.
-pub struct TagScanner<S: TagHintSink> {
+pub(crate) struct TagScanner<S> {
     next_pos: usize,
     is_last_input: bool,
     tag_start: Option<usize>,

--- a/src/parser/tree_builder_simulator/ambiguity_guard.rs
+++ b/src/parser/tree_builder_simulator/ambiguity_guard.rs
@@ -132,7 +132,7 @@ enum State {
     InOrAfterFrameset,
 }
 
-pub struct AmbiguityGuard {
+pub(crate) struct AmbiguityGuard {
     state: State,
 }
 

--- a/src/parser/tree_builder_simulator/mod.rs
+++ b/src/parser/tree_builder_simulator/mod.rs
@@ -24,7 +24,7 @@ pub use self::ambiguity_guard::ParsingAmbiguityError;
 const DEFAULT_NS_STACK_CAPACITY: usize = 256;
 
 #[must_use]
-pub enum TreeBuilderFeedback {
+pub(crate) enum TreeBuilderFeedback {
     SwitchTextType(TextType),
     SetAllowCdata(bool),
     #[allow(clippy::type_complexity)]
@@ -114,7 +114,7 @@ fn is_html_integration_point_in_svg(tag_name: LocalNameHash) -> bool {
 }
 
 // TODO limit ns stack
-pub struct TreeBuilderSimulator {
+pub(crate) struct TreeBuilderSimulator {
     ns_stack: Vec<Namespace>,
     current_ns: Namespace,
     ambiguity_guard: AmbiguityGuard,
@@ -173,7 +173,7 @@ impl TreeBuilderSimulator {
     }
 
     #[inline]
-    pub fn current_ns(&self) -> Namespace {
+    pub const fn current_ns(&self) -> Namespace {
         self.current_ns
     }
 

--- a/src/rewritable_units/mod.rs
+++ b/src/rewritable_units/mod.rs
@@ -93,7 +93,7 @@ mod test_utils {
     use encoding_rs::Encoding;
     use std::borrow::Cow;
 
-    pub fn encoded(input: &str) -> Vec<(Vec<u8>, &'static Encoding)> {
+    pub(crate) fn encoded(input: &str) -> Vec<(Vec<u8>, &'static Encoding)> {
         ASCII_COMPATIBLE_ENCODINGS
             .iter()
             .filter_map(|enc| {
@@ -115,7 +115,7 @@ mod test_utils {
             .collect()
     }
 
-    pub fn rewrite_html<'h>(
+    pub(crate) fn rewrite_html<'h>(
         html: &[u8],
         encoding: &'static Encoding,
         element_content_handlers: Vec<(Cow<'_, Selector>, ElementContentHandlers<'h>)>,

--- a/src/rewritable_units/tokens/attributes.rs
+++ b/src/rewritable_units/tokens/attributes.rs
@@ -43,7 +43,12 @@ pub struct Attribute<'i> {
 impl<'i> Attribute<'i> {
     #[inline]
     #[must_use]
-    fn new(name: Bytes<'i>, value: Bytes<'i>, raw: Bytes<'i>, encoding: &'static Encoding) -> Self {
+    const fn new(
+        name: Bytes<'i>,
+        value: Bytes<'i>,
+        raw: Bytes<'i>,
+        encoding: &'static Encoding,
+    ) -> Self {
         Attribute {
             name,
             value,
@@ -144,7 +149,7 @@ impl Debug for Attribute<'_> {
     }
 }
 
-pub struct Attributes<'i> {
+pub(crate) struct Attributes<'i> {
     input: &'i Bytes<'i>,
     attribute_buffer: &'i AttributeBuffer,
     items: LazyCell<Vec<Attribute<'i>>>,
@@ -235,7 +240,7 @@ impl<'i> Attributes<'i> {
     }
 
     #[cfg(test)]
-    pub fn raw_attributes(&self) -> (&'i Bytes<'i>, &'i AttributeBuffer) {
+    pub(crate) const fn raw_attributes(&self) -> (&'i Bytes<'i>, &'i AttributeBuffer) {
         (self.input, self.attribute_buffer)
     }
 }

--- a/src/rewritable_units/tokens/capturer/mod.rs
+++ b/src/rewritable_units/tokens/capturer/mod.rs
@@ -8,7 +8,7 @@ use crate::parser::Lexeme;
 use crate::rewriter::RewritingError;
 use bitflags::bitflags;
 
-pub use self::to_token::{ToToken, ToTokenResult};
+pub(crate) use self::to_token::{ToToken, ToTokenResult};
 
 bitflags! {
     #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -22,7 +22,7 @@ bitflags! {
 }
 
 #[derive(Debug)]
-pub enum TokenCapturerEvent<'i> {
+pub(crate) enum TokenCapturerEvent<'i> {
     LexemeConsumed,
     TokenProduced(Box<Token<'i>>),
 }

--- a/src/rewritable_units/tokens/capturer/text_decoder.rs
+++ b/src/rewritable_units/tokens/capturer/text_decoder.rs
@@ -14,7 +14,7 @@ macro_rules! emit {
     }};
 }
 
-pub struct TextDecoder {
+pub(crate) struct TextDecoder {
     encoding: SharedEncoding,
     pending_text_streaming_decoder: Option<Decoder>,
     text_buffer: String,

--- a/src/rewritable_units/tokens/capturer/to_token.rs
+++ b/src/rewritable_units/tokens/capturer/to_token.rs
@@ -3,7 +3,7 @@ use crate::html::TextType;
 use crate::parser::{NonTagContentLexeme, NonTagContentTokenOutline, TagLexeme, TagTokenOutline};
 use encoding_rs::Encoding;
 
-pub enum ToTokenResult<'i> {
+pub(crate) enum ToTokenResult<'i> {
     Token(Box<Token<'i>>),
     Text(TextType),
     None,
@@ -16,7 +16,7 @@ impl<'i> From<Token<'i>> for ToTokenResult<'i> {
     }
 }
 
-pub trait ToToken {
+pub(crate) trait ToToken {
     fn to_token(
         &self,
         capture_flags: &mut TokenCaptureFlags,

--- a/src/rewritable_units/tokens/mod.rs
+++ b/src/rewritable_units/tokens/mod.rs
@@ -7,6 +7,7 @@ pub(super) use self::attributes::Attributes;
 pub use self::attributes::{Attribute, AttributeNameError};
 pub use self::capturer::*;
 
+// Pub only for integration tests
 pub trait Serialize {
     fn to_bytes(&self, output_handler: &mut dyn FnMut(&[u8]));
 }
@@ -57,6 +58,7 @@ pub use self::end_tag::EndTag;
 pub use self::start_tag::StartTag;
 pub use self::text_chunk::TextChunk;
 
+// Pub only for integration tests
 #[derive(Debug)]
 pub enum Token<'i> {
     TextChunk(TextChunk<'i>),

--- a/src/rewritable_units/tokens/start_tag.rs
+++ b/src/rewritable_units/tokens/start_tag.rs
@@ -169,7 +169,9 @@ impl<'i> StartTag<'i> {
     }
 
     #[cfg(test)]
-    pub(crate) fn raw_attributes(&self) -> (&'i Bytes<'i>, &'i crate::parser::AttributeBuffer) {
+    pub(crate) const fn raw_attributes(
+        &self,
+    ) -> (&'i Bytes<'i>, &'i crate::parser::AttributeBuffer) {
         self.attributes.raw_attributes()
     }
 }

--- a/src/rewriter/handlers_dispatcher.rs
+++ b/src/rewriter/handlers_dispatcher.rs
@@ -4,7 +4,7 @@ use crate::rewritable_units::{DocumentEnd, Element, StartTag, Token, TokenCaptur
 use crate::selectors_vm::MatchInfo;
 
 #[derive(Copy, Clone, Default, Debug, PartialEq, Eq, Hash)]
-pub struct SelectorHandlersLocator {
+pub(crate) struct SelectorHandlersLocator {
     pub element_handler_idx: Option<usize>,
     pub comment_handler_idx: Option<usize>,
     pub text_handler_idx: Option<usize>,
@@ -59,7 +59,7 @@ impl<H> HandlerVec<H> {
     }
 
     #[inline]
-    pub fn has_active(&self) -> bool {
+    pub const fn has_active(&self) -> bool {
         self.user_count > 0
     }
 
@@ -112,7 +112,7 @@ impl<H> HandlerVec<H> {
     }
 }
 
-pub struct ContentHandlersDispatcher<'h, H: HandlerTypes> {
+pub(crate) struct ContentHandlersDispatcher<'h, H: HandlerTypes> {
     doctype_handlers: HandlerVec<H::DoctypeHandler<'h>>,
     comment_handlers: HandlerVec<H::CommentHandler<'h>>,
     text_handlers: HandlerVec<H::TextHandler<'h>>,
@@ -180,7 +180,7 @@ impl<'h, H: HandlerTypes> ContentHandlersDispatcher<'h, H> {
     }
 
     #[inline]
-    pub fn has_matched_elements_with_removed_content(&self) -> bool {
+    pub const fn has_matched_elements_with_removed_content(&self) -> bool {
         self.matched_elements_with_removed_content > 0
     }
 

--- a/src/rewriter/mod.rs
+++ b/src/rewriter/mod.rs
@@ -780,8 +780,8 @@ mod tests {
 
     mod fatal_errors {
         use super::*;
-        use crate::errors::MemoryLimitExceededError;
         use crate::html_content::Comment;
+        use crate::memory::MemoryLimitExceededError;
         use crate::rewritable_units::{Element, TextChunk};
 
         fn create_rewriter<O: OutputSink>(

--- a/src/rewriter/rewrite_controller.rs
+++ b/src/rewriter/rewrite_controller.rs
@@ -7,7 +7,7 @@ use crate::transform_stream::*;
 use hashbrown::HashSet;
 
 #[derive(Default)]
-pub struct ElementDescriptor {
+pub(crate) struct ElementDescriptor {
     pub matched_content_handlers: HashSet<SelectorHandlersLocator>,
     pub end_tag_handler_idx: Option<usize>,
     pub remove_content: bool,
@@ -22,14 +22,14 @@ impl ElementData for ElementDescriptor {
     }
 }
 
-pub struct HtmlRewriteController<'h, H: HandlerTypes> {
+pub(crate) struct HtmlRewriteController<'h, H: HandlerTypes> {
     handlers_dispatcher: ContentHandlersDispatcher<'h, H>,
     selector_matching_vm: Option<SelectorMatchingVm<ElementDescriptor>>,
 }
 
 impl<'h, H: HandlerTypes> HtmlRewriteController<'h, H> {
     #[inline]
-    pub fn new(
+    pub(crate) const fn new(
         handlers_dispatcher: ContentHandlersDispatcher<'h, H>,
         selector_matching_vm: Option<SelectorMatchingVm<ElementDescriptor>>,
     ) -> Self {

--- a/src/selectors_vm/ast.rs
+++ b/src/selectors_vm/ast.rs
@@ -6,7 +6,7 @@ use std::fmt::{self, Debug, Formatter};
 use std::hash::Hash;
 
 #[derive(PartialEq, Eq, Debug, Copy, Clone)]
-pub struct NthChild {
+pub(crate) struct NthChild {
     step: i32,
     offset: i32,
 }
@@ -46,7 +46,7 @@ impl NthChild {
 }
 
 #[derive(PartialEq, Eq, Debug)]
-pub enum OnTagNameExpr {
+pub(crate) enum OnTagNameExpr {
     ExplicitAny,
     Unmatchable,
     LocalName(String),
@@ -55,7 +55,7 @@ pub enum OnTagNameExpr {
 }
 
 #[derive(Eq, PartialEq)]
-pub struct AttributeComparisonExpr {
+pub(crate) struct AttributeComparisonExpr {
     pub name: String,
     pub value: String,
     pub case_sensitivity: ParsedCaseSensitivity,
@@ -104,7 +104,7 @@ impl Debug for AttributeComparisonExpr {
 
 /// An attribute check when attributes are received and parsed.
 #[derive(PartialEq, Eq, Debug)]
-pub enum OnAttributesExpr {
+pub(crate) enum OnAttributesExpr {
     Id(String),
     Class(String),
     AttributeExists(String),
@@ -173,7 +173,7 @@ impl From<&Component<SelectorImplDescriptor>> for Condition {
 }
 
 #[derive(PartialEq, Eq, Debug)]
-pub struct Expr<E>
+pub(crate) struct Expr<E>
 where
     E: PartialEq + Eq + Debug,
 {
@@ -195,7 +195,7 @@ where
 }
 
 #[derive(PartialEq, Eq, Debug, Default)]
-pub struct Predicate {
+pub(crate) struct Predicate {
     pub on_tag_name_exprs: Vec<Expr<OnTagNameExpr>>,
     pub on_attr_exprs: Vec<Expr<OnAttributesExpr>>,
 }
@@ -219,7 +219,7 @@ impl Predicate {
 }
 
 #[derive(PartialEq, Eq, Debug)]
-pub struct AstNode<P>
+pub(crate) struct AstNode<P>
 where
     P: Hash + Eq,
 {
@@ -243,14 +243,15 @@ where
     }
 }
 
+// exposed for selectors_ast tool
 #[derive(Default, PartialEq, Eq, Debug)]
 pub struct Ast<P>
 where
     P: PartialEq + Eq + Copy + Debug + Hash,
 {
-    pub root: Vec<AstNode<P>>,
+    pub(crate) root: Vec<AstNode<P>>,
     // NOTE: used to preallocate instruction vector during compilation.
-    pub cumulative_node_count: usize,
+    pub(crate) cumulative_node_count: usize,
 }
 
 impl<P> Ast<P>

--- a/src/selectors_vm/attribute_matcher.rs
+++ b/src/selectors_vm/attribute_matcher.rs
@@ -20,7 +20,7 @@ const fn is_attr_whitespace(b: u8) -> bool {
 
 type MemoizedAttrValue<'i> = LazyCell<Option<Bytes<'i>>>;
 
-pub struct AttributeMatcher<'i> {
+pub(crate) struct AttributeMatcher<'i> {
     input: &'i Bytes<'i>,
     attributes: &'i AttributeBuffer,
     id: MemoizedAttrValue<'i>,

--- a/src/selectors_vm/compiler.rs
+++ b/src/selectors_vm/compiler.rs
@@ -24,7 +24,7 @@ struct ExprSet {
     pub attribute_exprs: Vec<CompiledAttributeExpr>,
 }
 
-pub struct AttrExprOperands {
+pub(crate) struct AttrExprOperands {
     pub name: Bytes<'static>,
     pub value: Bytes<'static>,
     pub case_sensitivity: ParsedCaseSensitivity,
@@ -187,7 +187,7 @@ impl Compilable for Expr<OnAttributesExpr> {
     }
 }
 
-pub struct Compiler<P>
+pub(crate) struct Compiler<P>
 where
     P: PartialEq + Eq + Copy + Debug + Hash,
 {

--- a/src/selectors_vm/mod.rs
+++ b/src/selectors_vm/mod.rs
@@ -16,19 +16,19 @@ use crate::transform_stream::AuxStartTagInfo;
 use encoding_rs::Encoding;
 
 pub use self::ast::*;
-pub use self::attribute_matcher::AttributeMatcher;
-pub use self::compiler::Compiler;
+pub(crate) use self::attribute_matcher::AttributeMatcher;
+pub(crate) use self::compiler::Compiler;
 pub use self::error::SelectorError;
 pub use self::parser::Selector;
-pub use self::program::{ExecutionBranch, Program, TryExecResult};
-pub use self::stack::{ChildCounter, ElementData, Stack, StackItem};
+pub(crate) use self::program::{ExecutionBranch, Program, TryExecResult};
+pub(crate) use self::stack::{ChildCounter, ElementData, Stack, StackItem};
 
-pub struct MatchInfo<P> {
+pub(crate) struct MatchInfo<P> {
     pub payload: P,
     pub with_content: bool,
 }
 
-pub type AuxStartTagInfoRequest<E, P> = Box<
+pub(crate) type AuxStartTagInfoRequest<E, P> = Box<
     dyn FnOnce(
             &mut SelectorMatchingVm<E>,
             AuxStartTagInfo<'_>,
@@ -37,7 +37,7 @@ pub type AuxStartTagInfoRequest<E, P> = Box<
         + Send,
 >;
 
-pub enum VmError<E: ElementData, MatchPayload> {
+pub(crate) enum VmError<E: ElementData, MatchPayload> {
     InfoRequest(AuxStartTagInfoRequest<E, MatchPayload>),
     MemoryLimitExceeded(MemoryLimitExceededError),
 }
@@ -69,7 +69,7 @@ struct Bailout<T> {
 }
 
 /// A container for tracking state from various places on the stack.
-pub struct SelectorState<'i> {
+pub(crate) struct SelectorState<'i> {
     pub cumulative: &'i ChildCounter,
     pub typed: Option<&'i ChildCounter>,
 }
@@ -140,7 +140,7 @@ macro_rules! aux_info_request {
     };
 }
 
-pub struct SelectorMatchingVm<E: ElementData> {
+pub(crate) struct SelectorMatchingVm<E: ElementData> {
     program: Program<E::MatchPayload>,
     stack: Stack<E>,
     enable_esi_tags: bool,

--- a/src/selectors_vm/parser.rs
+++ b/src/selectors_vm/parser.rs
@@ -9,7 +9,7 @@ use std::fmt;
 use std::str::FromStr;
 
 #[derive(Debug, Clone, Eq, PartialEq)]
-pub struct SelectorImplDescriptor;
+pub(crate) struct SelectorImplDescriptor;
 
 impl SelectorImpl for SelectorImplDescriptor {
     type AttrValue = String;
@@ -29,7 +29,7 @@ impl SelectorImpl for SelectorImplDescriptor {
 }
 
 #[derive(PartialEq, Eq, Clone, Debug, Hash)]
-pub enum PseudoElementStub {}
+pub(crate) enum PseudoElementStub {}
 
 impl ToCss for PseudoElementStub {
     fn to_css<W: fmt::Write>(&self, _dest: &mut W) -> fmt::Result {
@@ -43,7 +43,7 @@ impl PseudoElement for PseudoElementStub {
 }
 
 #[derive(PartialEq, Eq, Clone, Debug, Hash)]
-pub enum NonTSPseudoClassStub {}
+pub(crate) enum NonTSPseudoClassStub {}
 
 impl NonTSPseudoClass for NonTSPseudoClassStub {
     type Impl = SelectorImplDescriptor;

--- a/src/selectors_vm/program.rs
+++ b/src/selectors_vm/program.rs
@@ -6,10 +6,10 @@ use hashbrown::HashSet;
 use std::hash::Hash;
 use std::ops::Range;
 
-pub type AddressRange = Range<usize>;
+pub(crate) type AddressRange = Range<usize>;
 
 #[derive(Debug, PartialEq, Eq)]
-pub struct ExecutionBranch<P>
+pub(crate) struct ExecutionBranch<P>
 where
     P: Hash + Eq,
 {
@@ -19,7 +19,7 @@ where
 }
 
 /// The result of trying to execute an instruction without having parsed all attributes
-pub enum TryExecResult<'i, P>
+pub(crate) enum TryExecResult<'i, P>
 where
     P: Hash + Eq,
 {
@@ -31,7 +31,7 @@ where
     Fail,
 }
 
-pub struct Instruction<P>
+pub(crate) struct Instruction<P>
 where
     P: Hash + Eq,
 {
@@ -89,7 +89,7 @@ where
     }
 }
 
-pub struct Program<P>
+pub(crate) struct Program<P>
 where
     P: Hash + Eq,
 {

--- a/src/selectors_vm/stack.rs
+++ b/src/selectors_vm/stack.rs
@@ -37,20 +37,20 @@ fn is_void_element(local_name: &LocalName<'_>, enable_esi_tags: bool) -> bool {
     false
 }
 
-pub trait ElementData: Default + 'static {
+pub(crate) trait ElementData: Default + 'static {
     type MatchPayload: PartialEq + Eq + Copy + Debug + Hash + 'static;
 
     fn matched_payload_mut(&mut self) -> &mut HashSet<Self::MatchPayload>;
 }
 
-pub enum StackDirective {
+pub(crate) enum StackDirective {
     Push,
     PushIfNotSelfClosing,
     PopImmediately,
 }
 
 #[derive(Default)]
-pub struct ChildCounter {
+pub(crate) struct ChildCounter {
     cumulative: i32,
 }
 
@@ -100,7 +100,7 @@ impl CounterList {
 
 #[derive(Default)]
 /// A more efficient counter that only requires one owned local name to track counters across multiple stack frames
-pub struct TypedChildCounterMap(HashMap<LocalName<'static>, CounterList>);
+pub(crate) struct TypedChildCounterMap(HashMap<LocalName<'static>, CounterList>);
 
 impl TypedChildCounterMap {
     fn hash_name(&self, name: &LocalName<'_>) -> u64 {
@@ -166,7 +166,7 @@ impl TypedChildCounterMap {
     }
 }
 
-pub struct StackItem<'i, E: ElementData> {
+pub(crate) struct StackItem<'i, E: ElementData> {
     pub local_name: LocalName<'i>,
     pub element_data: E,
     pub jumps: Vec<AddressRange>,
@@ -205,7 +205,7 @@ impl<'i, E: ElementData> StackItem<'i, E> {
     }
 }
 
-pub struct Stack<E: ElementData> {
+pub(crate) struct Stack<E: ElementData> {
     /// A counter for root elements
     root_child_counter: ChildCounter,
     /// A typed counter for all elements on all frames. This is optional to indicate if types are actually being counted.

--- a/src/transform_stream/dispatcher.rs
+++ b/src/transform_stream/dispatcher.rs
@@ -11,7 +11,7 @@ use crate::rewriter::RewritingError;
 
 use TagTokenOutline::{EndTag, StartTag};
 
-pub struct AuxStartTagInfo<'i> {
+pub(crate) struct AuxStartTagInfo<'i> {
     pub input: &'i Bytes<'i>,
     pub attr_buffer: &'i AttributeBuffer,
     pub self_closing: bool,
@@ -21,13 +21,17 @@ type AuxStartTagInfoRequest<C> = Box<
     dyn FnOnce(&mut C, AuxStartTagInfo<'_>) -> Result<TokenCaptureFlags, RewritingError> + Send,
 >;
 
+// Pub only for integration tests
+#[allow(private_interfaces)]
 pub enum DispatcherError<C> {
     InfoRequest(AuxStartTagInfoRequest<C>),
     RewritingError(RewritingError),
 }
 
+// Pub only for integration tests
 pub type StartTagHandlingResult<C> = Result<TokenCaptureFlags, DispatcherError<C>>;
 
+// Pub only for integration tests
 pub trait TransformController: Sized {
     fn initial_capture_flags(&self) -> TokenCaptureFlags;
     fn handle_start_tag(
@@ -62,6 +66,7 @@ impl<F: FnMut(&[u8])> OutputSink for F {
     }
 }
 
+// Pub only for integration tests
 pub struct Dispatcher<C, O>
 where
     C: TransformController,

--- a/src/transform_stream/mod.rs
+++ b/src/transform_stream/mod.rs
@@ -1,14 +1,15 @@
 mod dispatcher;
 
 use self::dispatcher::Dispatcher;
-pub use self::dispatcher::{
-    AuxStartTagInfo, DispatcherError, OutputSink, StartTagHandlingResult, TransformController,
-};
+pub use self::dispatcher::OutputSink;
+pub(crate) use self::dispatcher::{AuxStartTagInfo, DispatcherError};
+pub use self::dispatcher::{StartTagHandlingResult, TransformController};
 use crate::base::SharedEncoding;
 use crate::memory::{Arena, SharedMemoryLimiter};
 use crate::parser::{Parser, ParserDirective};
 use crate::rewriter::RewritingError;
 
+// Pub only for integration tests
 pub struct TransformStreamSettings<C, O>
 where
     C: TransformController,
@@ -22,6 +23,7 @@ where
     pub strict: bool,
 }
 
+// Pub only for integration tests
 pub struct TransformStream<C, O>
 where
     C: TransformController,
@@ -134,6 +136,7 @@ where
     }
 
     #[cfg(feature = "integration_test")]
+    #[allow(private_interfaces)]
     pub fn parser(&mut self) -> &mut Parser<Dispatcher<C, O>> {
         &mut self.parser
     }


### PR DESCRIPTION
Integration tests publicly export a bunch of things, so it was difficult for me to see what actually is part of the public API. 

Plus a handful of `const fn`s on private methods, just because.