### PR TITLE
Update hashbrown to v0.15.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,15 +41,15 @@ lazy_static = "1.3.0"
 memchr = "2.1.2"
 selectors = "0.22.0"
 thiserror = "1.0.2"
-hashbrown = "0.13.1"
+hashbrown = "0.15.0"
 mime = "0.3.16"
 
 [dev-dependencies]
-criterion = "0.4.0"
+criterion = "0.5.1"
 glob = "0.3.0"
 html5ever = "0.26.0"
 markup5ever_rcdom = "0.2.0"
-hashbrown = { version = "0.13.1", features = ["serde"] }
+hashbrown = { version = "0.15.0", features = ["serde"] }
 serde = "1.0.126"
 serde_derive = "1.0.19"
 serde_json = "1.0.65"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,6 +46,7 @@ mime = "0.3.16"
 
 [dev-dependencies]
 criterion = "0.5.1"
+clap = { version = "*", features = ["help"] } # for criterion <= v0.5.1
 glob = "0.3.0"
 html5ever = "0.26.0"
 markup5ever_rcdom = "0.2.0"


### PR DESCRIPTION
https://github.com/cloudflare/lol-html/issues/218 describes the situation pretty well; I think a lot of downstream users would appreciate if this could be merged!

I've included a bump to `criterion` in this PR since it also indirectly depended on `hashbrown 0.12`.

Closes https://github.com/cloudflare/lol-html/issues/218