### PR TITLE
[RFC] Partially update selectors

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,7 +39,8 @@ encoding_rs = "0.8.13"
 memchr = "2.1.2"
 hashbrown = "0.15.0"
 mime = "0.3.16"
-selectors = "0.24"
+# HACK: Using commit between 0.24 and 0.25, allows us to get rid of phf 0.8.
+selectors = {git = "https://github.com/servo/stylo.git", rev = "767bc8bc11424d107cd58c7c2d3a1695e387e4ea"}
 thiserror = "2.0"
 
 [dev-dependencies]

--- a/src/selectors_vm/parser.rs
+++ b/src/selectors_vm/parser.rs
@@ -38,7 +38,7 @@ impl SelectorImpl for SelectorImplDescriptor {
     type NonTSPseudoClass = NonTSPseudoClassStub;
     type PseudoElement = PseudoElementStub;
 
-    type ExtraMatchingData = ();
+    type ExtraMatchingData<'a> = std::marker::PhantomData<&'a ()>;
 }
 
 #[derive(PartialEq, Eq, Clone, Debug, Hash)]
@@ -127,6 +127,7 @@ impl SelectorsParser {
             | Component::Part(_)
             | Component::Host(_)
             | Component::Is(_)
+            | Component::Has(_)
             | Component::LastChild
             | Component::LastOfType
             | Component::NthLastChild(_, _)


### PR DESCRIPTION
I'm delighted that we bumped the cssparser and selectors versions in #248 after they had been stuck for a while.
For workerd, updating these packages further is desirable as it would allow us to get rid of some old crates – notably phf 0.8, which is now 5 years old and pulls in more outdated packages. I tried to update to selectors 0.25/cssparser 0.31, with some success – I was able to get the build to work but am not sure how to fix the test cases after some selectors types were added/removed (see [felix/selectors-update](https://github.com/fhanau/lol-html/tree/felix/selectors-update)).

To make at least some progress here, we could update to a specific commit instead. This would be sufficient to move phf forward but require fewer lol-html changes. At the same time, a given commit might be less stable than a tagged release version. Let me know what you think about updating this further – if this approach feels sensible, or if moving directly to selectors 0.25 is feasible. I hope this doesn't duplicates any work you have already been doing.

Relevant selectors commits:
to_unconditional: https://github.com/servo/stylo/commit/8c33b56bbcd65a43e136fcac20782db21148af72
ExtraMatchingData: https://github.com/servo/stylo/commit/767bc8bc11424d107cd58c7c2d3a1695e387e4ea
Has: https://github.com/servo/stylo/commit/789476f49e2b8c93f9f233d33781970b66594467