### PR TITLE
diagnostic::on_unimplemented

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -62,11 +62,13 @@ pub mod send {
     pub use crate::rewriter::{IntoHandler, SendHandlerTypes};
 
     /// An [`HtmlRewriter`](crate::HtmlRewriter) that implements [`Send`].
-    pub type HtmlRewriter<'h, O> = crate::HtmlRewriter<'h, O, SendHandlerTypes>;
+    pub type HtmlRewriter<'handlers, O> = crate::HtmlRewriter<'handlers, O, SendHandlerTypes>;
     /// [`Settings`](crate::Settings) for [`Send`]able [`HtmlRewriter`](crate::HtmlRewriter)s.
-    pub type Settings<'h, 's> = crate::Settings<'h, 's, SendHandlerTypes>;
+    pub type Settings<'handlers, 'selectors> =
+        crate::Settings<'handlers, 'selectors, SendHandlerTypes>;
     /// [`RewriteStrSettings`](crate::RewriteStrSettings) for [`Send`]able [`HtmlRewriter`](crate::HtmlRewriter)s.
-    pub type RewriteStrSettings<'h, 's> = crate::RewriteStrSettings<'h, 's, SendHandlerTypes>;
+    pub type RewriteStrSettings<'handlers, 'selectors> =
+        crate::RewriteStrSettings<'handlers, 'selectors, SendHandlerTypes>;
 
     /// [`ElementContentHandlers`](crate::ElementContentHandlers) for [`Send`]able [`HtmlRewriter`](crate::HtmlRewriter)s.
     pub type ElementContentHandlers<'h> = crate::ElementContentHandlers<'h, SendHandlerTypes>;
@@ -74,7 +76,8 @@ pub mod send {
     pub type DocumentContentHandlers<'h> = crate::DocumentContentHandlers<'h, SendHandlerTypes>;
 
     /// [`Element`](crate::rewritable_units::Element) for [`Send`]able [`HtmlRewriter`](crate::HtmlRewriter)s.
-    pub type Element<'r, 't> = crate::rewritable_units::Element<'r, 't, SendHandlerTypes>;
+    pub type Element<'rewriter, 'input_token> =
+        crate::rewritable_units::Element<'rewriter, 'input_token, SendHandlerTypes>;
 }
 
 /// The errors that can be produced by the crate's API.

--- a/src/rewritable_units/element.rs
+++ b/src/rewritable_units/element.rs
@@ -38,8 +38,8 @@ pub enum TagNameError {
 /// An HTML element rewritable unit.
 ///
 /// Exposes API for examination and modification of a parsed HTML element.
-pub struct Element<'r, 't, H: HandlerTypes = LocalHandlerTypes> {
-    start_tag: &'r mut StartTag<'t>,
+pub struct Element<'rewriter, 'input_token, H: HandlerTypes = LocalHandlerTypes> {
+    start_tag: &'rewriter mut StartTag<'input_token>,
     end_tag_mutations: Option<Mutations>,
     modified_end_tag_name: Option<Box<[u8]>>,
     end_tag_handlers: Vec<H::EndTagHandler<'static>>,
@@ -49,10 +49,13 @@ pub struct Element<'r, 't, H: HandlerTypes = LocalHandlerTypes> {
     user_data: Box<dyn Any>,
 }
 
-impl<'r, 't, H: HandlerTypes> Element<'r, 't, H> {
+impl<'rewriter, 'input_token, H: HandlerTypes> Element<'rewriter, 'input_token, H> {
     #[inline]
     #[must_use]
-    pub(crate) fn new(start_tag: &'r mut StartTag<'t>, can_have_content: bool) -> Self {
+    pub(crate) fn new(
+        start_tag: &'rewriter mut StartTag<'input_token>,
+        can_have_content: bool,
+    ) -> Self {
         let encoding = start_tag.encoding();
 
         Element {
@@ -182,7 +185,7 @@ impl<'r, 't, H: HandlerTypes> Element<'r, 't, H> {
     /// Returns an immutable collection of element's attributes.
     #[inline]
     #[must_use]
-    pub fn attributes(&self) -> &[Attribute<'t>] {
+    pub fn attributes(&self) -> &[Attribute<'input_token>] {
         self.start_tag.attributes()
     }
 
@@ -631,7 +634,7 @@ impl<'r, 't, H: HandlerTypes> Element<'r, 't, H> {
 
     /// Returns the start tag.
     #[inline]
-    pub fn start_tag(&mut self) -> &mut StartTag<'t> {
+    pub fn start_tag(&mut self) -> &mut StartTag<'input_token> {
         self.start_tag
     }
 

--- a/src/rewritable_units/element.rs
+++ b/src/rewritable_units/element.rs
@@ -271,7 +271,7 @@ impl<'r, 't, H: HandlerTypes> Element<'r, 't, H> {
     /// Consequent calls to the method append to the previously inserted content.
     ///
     /// Use the [`streaming!`] macro to make a `StreamingHandler` from a closure.
-    pub fn streaming_before(&mut self, string_writer: Box<dyn StreamingHandler + Send>) {
+    pub fn streaming_before(&mut self, string_writer: Box<dyn StreamingHandler + Send + 'static>) {
         self.start_tag
             .mutations
             .mutate()
@@ -327,7 +327,7 @@ impl<'r, 't, H: HandlerTypes> Element<'r, 't, H> {
     ///
     ///
     /// Use the [`streaming!`] macro to make a `StreamingHandler` from a closure.
-    pub fn streaming_after(&mut self, string_writer: Box<dyn StreamingHandler + Send>) {
+    pub fn streaming_after(&mut self, string_writer: Box<dyn StreamingHandler + Send + 'static>) {
         self.after_chunk(StringChunk::stream(string_writer));
     }
 
@@ -392,7 +392,7 @@ impl<'r, 't, H: HandlerTypes> Element<'r, 't, H> {
     ///
     ///
     /// Use the [`streaming!`] macro to make a `StreamingHandler` from a closure.
-    pub fn streaming_prepend(&mut self, string_writer: Box<dyn StreamingHandler + Send>) {
+    pub fn streaming_prepend(&mut self, string_writer: Box<dyn StreamingHandler + Send + 'static>) {
         self.prepend_chunk(StringChunk::stream(string_writer));
     }
 
@@ -452,7 +452,7 @@ impl<'r, 't, H: HandlerTypes> Element<'r, 't, H> {
     /// [empty element]: https://developer.mozilla.org/en-US/docs/Glossary/Empty_element
     ///
     /// Use the [`streaming!`] macro to make a `StreamingHandler` from a closure.
-    pub fn streaming_append(&mut self, string_writer: Box<dyn StreamingHandler + Send>) {
+    pub fn streaming_append(&mut self, string_writer: Box<dyn StreamingHandler + Send + 'static>) {
         self.append_chunk(StringChunk::stream(string_writer));
     }
 
@@ -516,7 +516,10 @@ impl<'r, 't, H: HandlerTypes> Element<'r, 't, H> {
     ///
     ///
     /// Use the [`streaming!`] macro to make a `StreamingHandler` from a closure.
-    pub fn streaming_set_inner_content(&mut self, string_writer: Box<dyn StreamingHandler + Send>) {
+    pub fn streaming_set_inner_content(
+        &mut self,
+        string_writer: Box<dyn StreamingHandler + Send + 'static>,
+    ) {
         self.set_inner_content_chunk(StringChunk::stream(string_writer));
     }
 
@@ -567,7 +570,7 @@ impl<'r, 't, H: HandlerTypes> Element<'r, 't, H> {
     ///
     ///
     /// Use the [`streaming!`] macro to make a `StreamingHandler` from a closure.
-    pub fn streaming_replace(&mut self, string_writer: Box<dyn StreamingHandler + Send>) {
+    pub fn streaming_replace(&mut self, string_writer: Box<dyn StreamingHandler + Send + 'static>) {
         self.replace_chunk(StringChunk::stream(string_writer));
     }
 

--- a/src/rewritable_units/tokens/comment.rs
+++ b/src/rewritable_units/tokens/comment.rs
@@ -126,7 +126,7 @@ impl<'i> Comment<'i> {
     ///
     /// Use the [`streaming!`] macro to make a `StreamingHandler` from a closure.
     #[inline]
-    pub fn streaming_before(&mut self, string_writer: Box<dyn StreamingHandler + Send>) {
+    pub fn streaming_before(&mut self, string_writer: Box<dyn StreamingHandler + Send + 'static>) {
         self.mutations
             .mutate()
             .content_before
@@ -174,7 +174,7 @@ impl<'i> Comment<'i> {
     ///
     /// Use the [`streaming!`] macro to make a `StreamingHandler` from a closure.
     #[inline]
-    pub fn streaming_after(&mut self, string_writer: Box<dyn StreamingHandler + Send>) {
+    pub fn streaming_after(&mut self, string_writer: Box<dyn StreamingHandler + Send + 'static>) {
         self.mutations
             .mutate()
             .content_after
@@ -221,7 +221,7 @@ impl<'i> Comment<'i> {
     ///
     /// Use the [`streaming!`] macro to make a `StreamingHandler` from a closure.
     #[inline]
-    pub fn streaming_replace(&mut self, string_writer: Box<dyn StreamingHandler + Send>) {
+    pub fn streaming_replace(&mut self, string_writer: Box<dyn StreamingHandler + Send + 'static>) {
         self.mutations
             .mutate()
             .replace(StringChunk::stream(string_writer));

--- a/src/rewritable_units/tokens/end_tag.rs
+++ b/src/rewritable_units/tokens/end_tag.rs
@@ -115,7 +115,7 @@ impl<'i> EndTag<'i> {
     ///
     /// Use the [`streaming!`] macro to make a `StreamingHandler` from a closure.
     #[inline]
-    pub fn streaming_before(&mut self, string_writer: Box<dyn StreamingHandler + Send>) {
+    pub fn streaming_before(&mut self, string_writer: Box<dyn StreamingHandler + Send + 'static>) {
         self.mutations
             .mutate()
             .content_before
@@ -128,7 +128,7 @@ impl<'i> EndTag<'i> {
     ///
     /// Use the [`streaming!`] macro to make a `StreamingHandler` from a closure.
     #[inline]
-    pub fn streaming_after(&mut self, string_writer: Box<dyn StreamingHandler + Send>) {
+    pub fn streaming_after(&mut self, string_writer: Box<dyn StreamingHandler + Send + 'static>) {
         self.mutations
             .mutate()
             .content_after
@@ -141,7 +141,7 @@ impl<'i> EndTag<'i> {
     ///
     /// Use the [`streaming!`] macro to make a `StreamingHandler` from a closure.
     #[inline]
-    pub fn streaming_replace(&mut self, string_writer: Box<dyn StreamingHandler + Send>) {
+    pub fn streaming_replace(&mut self, string_writer: Box<dyn StreamingHandler + Send + 'static>) {
         self.mutations
             .mutate()
             .replace(StringChunk::stream(string_writer));

--- a/src/rewritable_units/tokens/start_tag.rs
+++ b/src/rewritable_units/tokens/start_tag.rs
@@ -13,26 +13,26 @@ use std::fmt::{self, Debug};
 /// An HTML start tag rewritable unit.
 ///
 /// Exposes API for examination and modification of a parsed HTML start tag.
-pub struct StartTag<'i> {
-    name: BytesCow<'i>,
-    attributes: Attributes<'i>,
+pub struct StartTag<'input_token> {
+    name: BytesCow<'input_token>,
+    attributes: Attributes<'input_token>,
     ns: Namespace,
     self_closing: bool,
-    raw: SpannedRawBytes<'i>,
+    raw: SpannedRawBytes<'input_token>,
     pub(crate) mutations: Mutations,
 }
 
-impl<'i> StartTag<'i> {
+impl<'input_token> StartTag<'input_token> {
     /// Reuses encoding from `attributes`
     #[inline]
     #[must_use]
     pub(super) fn new_token(
-        name: Bytes<'i>,
-        attributes: Attributes<'i>,
+        name: Bytes<'input_token>,
+        attributes: Attributes<'input_token>,
         ns: Namespace,
         self_closing: bool,
-        raw: SpannedRawBytes<'i>,
-    ) -> Token<'i> {
+        raw: SpannedRawBytes<'input_token>,
+    ) -> Token<'input_token> {
         Token::StartTag(StartTag {
             name: name.into(),
             attributes,
@@ -93,7 +93,7 @@ impl<'i> StartTag<'i> {
 
     /// Returns an immutable collection of tag's attributes.
     #[inline]
-    pub fn attributes(&self) -> &[Attribute<'i>] {
+    pub fn attributes(&self) -> &[Attribute<'input_token>] {
         &self.attributes
     }
 
@@ -252,7 +252,10 @@ impl<'i> StartTag<'i> {
     #[cfg(test)]
     pub(crate) const fn raw_attributes(
         &self,
-    ) -> (&'i Bytes<'i>, &'i crate::parser::AttributeBuffer) {
+    ) -> (
+        &'input_token Bytes<'input_token>,
+        &'input_token crate::parser::AttributeBuffer,
+    ) {
         self.attributes.raw_attributes()
     }
 

--- a/src/rewritable_units/tokens/start_tag.rs
+++ b/src/rewritable_units/tokens/start_tag.rs
@@ -179,7 +179,7 @@ impl<'i> StartTag<'i> {
     /// Consequent calls to the method append to the previously inserted content.
     ///
     /// Use the [`streaming!`] macro to make a `StreamingHandler` from a closure.
-    pub fn streaming_before(&mut self, string_writer: Box<dyn StreamingHandler + Send>) {
+    pub fn streaming_before(&mut self, string_writer: Box<dyn StreamingHandler + Send + 'static>) {
         self.mutations
             .mutate()
             .content_before
@@ -191,7 +191,7 @@ impl<'i> StartTag<'i> {
     /// Consequent calls to the method prepend to the previously inserted content.
     ///
     /// Use the [`streaming!`] macro to make a `StreamingHandler` from a closure.
-    pub fn streaming_after(&mut self, string_writer: Box<dyn StreamingHandler + Send>) {
+    pub fn streaming_after(&mut self, string_writer: Box<dyn StreamingHandler + Send + 'static>) {
         self.mutations
             .mutate()
             .content_after
@@ -203,7 +203,7 @@ impl<'i> StartTag<'i> {
     /// Consequent calls to the method overwrite previous replacement content.
     ///
     /// Use the [`streaming!`] macro to make a `StreamingHandler` from a closure.
-    pub fn streaming_replace(&mut self, string_writer: Box<dyn StreamingHandler + Send>) {
+    pub fn streaming_replace(&mut self, string_writer: Box<dyn StreamingHandler + Send + 'static>) {
         self.mutations
             .mutate()
             .replace(StringChunk::stream(string_writer));

--- a/src/rewritable_units/tokens/text_chunk.rs
+++ b/src/rewritable_units/tokens/text_chunk.rs
@@ -309,7 +309,7 @@ impl<'i> TextChunk<'i> {
     /// Consequent calls to the method append `content` to the previously inserted content.
     ///
     /// Use the [`streaming!`] macro to make a `StreamingHandler` from a closure.
-    pub fn streaming_before(&mut self, string_writer: Box<dyn StreamingHandler + Send>) {
+    pub fn streaming_before(&mut self, string_writer: Box<dyn StreamingHandler + Send + 'static>) {
         self.mutations
             .mutate()
             .content_before
@@ -321,7 +321,7 @@ impl<'i> TextChunk<'i> {
     /// Consequent calls to the method prepend to the previously inserted content.
     ///
     /// Use the [`streaming!`] macro to make a `StreamingHandler` from a closure.
-    pub fn streaming_after(&mut self, string_writer: Box<dyn StreamingHandler + Send>) {
+    pub fn streaming_after(&mut self, string_writer: Box<dyn StreamingHandler + Send + 'static>) {
         self.mutations
             .mutate()
             .content_after
@@ -333,7 +333,7 @@ impl<'i> TextChunk<'i> {
     /// Consequent calls to the method overwrite previous replacement content.
     ///
     /// Use the [`streaming!`] macro to make a `StreamingHandler` from a closure.
-    pub fn streaming_replace(&mut self, string_writer: Box<dyn StreamingHandler + Send>) {
+    pub fn streaming_replace(&mut self, string_writer: Box<dyn StreamingHandler + Send + 'static>) {
         self.mutations
             .mutate()
             .replace(StringChunk::stream(string_writer));

--- a/src/rewriter/mod.rs
+++ b/src/rewriter/mod.rs
@@ -82,7 +82,7 @@ pub enum RewritingError {
 
     /// An error that was propagated from one of the content handlers.
     #[error("{0}")]
-    ContentHandlerError(Box<dyn StdError + Send + Sync>),
+    ContentHandlerError(Box<dyn StdError + Send + Sync + 'static>),
 }
 
 /// A streaming HTML rewriter.
@@ -327,7 +327,7 @@ mod tests {
     use std::sync::{Arc, Mutex};
 
     // Assert that HtmlRewriter with `SendHandlerTypes` is `Send`.
-    assert_impl_all!(crate::send::HtmlRewriter<'_, Box<dyn FnMut(&[u8]) + Send>>: Send);
+    assert_impl_all!(crate::send::HtmlRewriter<'_, Box<dyn FnMut(&[u8]) + Send + 'static>>: Send);
 
     fn write_chunks<O: OutputSink>(
         mut rewriter: HtmlRewriter<'_, O>,

--- a/src/selectors_vm/compiler.rs
+++ b/src/selectors_vm/compiler.rs
@@ -15,10 +15,11 @@ use std::iter;
 type BytesOwned = Box<[u8]>;
 
 /// An expression using only the tag name of an element.
-pub type CompiledLocalNameExpr = Box<dyn Fn(&SelectorState<'_>, &LocalName<'_>) -> bool + Send>;
+pub type CompiledLocalNameExpr =
+    Box<dyn Fn(&SelectorState<'_>, &LocalName<'_>) -> bool + Send + 'static>;
 /// An expression using the attributes of an element.
 pub type CompiledAttributeExpr =
-    Box<dyn Fn(&SelectorState<'_>, &AttributeMatcher<'_>) -> bool + Send>;
+    Box<dyn Fn(&SelectorState<'_>, &AttributeMatcher<'_>) -> bool + Send + 'static>;
 
 #[derive(Default)]
 struct ExprSet {


### PR DESCRIPTION
`diagnostic::on_unimplemented` adds extra info to errors about `IntoHandler` and `HandlerTypes`.

I've also made lifetime names more verbose, and made an implicit `+ 'static` specified explicitly, so they're less intimidating when lifetime-related errors happen.
