### PR TITLE
Code size optimizations

### DIFF
--- a/src/base/bytes.rs
+++ b/src/base/bytes.rs
@@ -96,7 +96,11 @@ impl<'b> Bytes<'b> {
 
     #[inline]
     pub(crate) fn slice(&self, range: Range) -> Self {
-        Self(&self.0[range.start..range.end])
+        debug_assert!(self.0.get(range.start..range.end).is_some());
+        // Optimizes to panic-free branchless
+        let end = range.end.min(self.0.len());
+        let start = range.start.min(end);
+        Self(&self.0[start..end])
     }
 
     #[inline]
@@ -107,7 +111,8 @@ impl<'b> Bytes<'b> {
 
     #[inline]
     pub(crate) fn opt_slice(&self, range: Option<Range>) -> Option<Self> {
-        range.map(|range| self.slice(range))
+        let range = range?;
+        self.0.get(range.start..range.end).map(Self)
     }
 
     pub(crate) fn as_debug_string(&self) -> String {

--- a/src/memory/limited_vec.rs
+++ b/src/memory/limited_vec.rs
@@ -21,8 +21,26 @@ impl<T> LimitedVec<T> {
     }
 
     pub fn push(&mut self, element: T) -> Result<(), MemoryLimitExceededError> {
-        self.limiter.increase_usage(size_of::<T>())?;
-        self.vec.push(element);
+        if self.vec.capacity() - self.vec.len() >= 1 {
+            // the two push calls are optimized into one, but need to be two so each gets its own capacity hint
+            self.vec.push(element);
+        } else {
+            // calculating the new capacity manually to check it before allocation
+            let additional = self.vec.capacity().max(Self::min_capacity());
+            let new_capacity = self.vec.capacity() + additional;
+            let additional_bytes = additional
+                .checked_mul(size_of::<T>())
+                .ok_or(MemoryLimitExceededError)?;
+            self.limiter.increase_usage(additional_bytes)?;
+
+            // exact to reserve what has been accounted for.
+            // not bothering with decrease_usage on real OOM, since the library won't recover anyway
+            self.vec
+                .try_reserve_exact(additional)
+                .map_err(|_| MemoryLimitExceededError)?;
+            debug_assert_eq!(new_capacity, self.vec.capacity());
+            self.vec.push(element);
+        }
         Ok(())
     }
 
@@ -50,23 +68,16 @@ impl<T> LimitedVec<T> {
     where
         R: RangeBounds<usize>,
     {
-        use std::ops::Bound::*;
-
-        let start = match range.start_bound() {
-            Included(&n) => n,
-            Excluded(&n) => n + 1,
-            Unbounded => 0,
-        };
-
-        let end = match range.end_bound() {
-            Included(&n) => n + 1,
-            Excluded(&n) => n,
-            Unbounded => self.len(),
-        };
-
-        self.limiter.decrease_usage(size_of::<T>() * (end - start));
-
         self.vec.drain(range)
+    }
+
+    const fn min_capacity() -> usize {
+        let items = 128 / size_of::<T>();
+        if items >= 8 {
+            items
+        } else {
+            8
+        }
     }
 }
 
@@ -75,21 +86,24 @@ impl<T> Deref for LimitedVec<T> {
 
     #[inline]
     fn deref(&self) -> &Self::Target {
-        self.vec.as_slice()
+        &self.vec
     }
 }
 
 impl<T> Index<usize> for LimitedVec<T> {
     type Output = T;
 
+    #[inline]
+    #[track_caller]
     fn index(&self, index: usize) -> &Self::Output {
-        &self.vec[index]
+        Index::index(&self.vec, index)
     }
 }
 
 impl<T> Drop for LimitedVec<T> {
     fn drop(&mut self) {
-        self.limiter.decrease_usage(size_of::<T>() * self.vec.len());
+        self.limiter
+            .decrease_usage(size_of::<T>() * self.vec.capacity());
     }
 }
 
@@ -98,74 +112,102 @@ mod tests {
     use super::super::SharedMemoryLimiter;
     use super::*;
 
-    #[test]
-    fn current_usage() {
-        {
-            let limiter = SharedMemoryLimiter::new(10);
-            let mut vec_u8: LimitedVec<u8> = LimitedVec::new(limiter.clone());
+    fn test_ty<T: Copy + Default>() -> (LimitedVec<T>, SharedMemoryLimiter) {
+        let initial_capacity = LimitedVec::<T>::min_capacity();
+        // allow 2x capacity to be able to observe growth
+        let limiter = SharedMemoryLimiter::new(2 * initial_capacity * size_of::<T>());
+        let vec1 = LimitedVec::<T>::new(limiter.clone());
+        let mut vec = LimitedVec::<T>::new(limiter.clone());
 
-            vec_u8.push(1).unwrap();
-            vec_u8.push(2).unwrap();
-            assert_eq!(limiter.current_usage(), 2);
+        assert_eq!(0, limiter.current_usage());
+        assert_eq!(0, vec1.vec.capacity());
+        drop(vec1);
+
+        vec.push(Default::default()).unwrap();
+        assert_eq!(initial_capacity, vec.vec.capacity());
+        assert_eq!(
+            limiter.current_usage(),
+            vec.vec.capacity() * size_of::<T>(),
+            "T={}",
+            size_of::<T>()
+        );
+        drop(vec);
+
+        assert_eq!(0, limiter.current_usage());
+        let mut vec = LimitedVec::<T>::new(limiter.clone());
+        for _ in 0..3 {
+            vec.push(Default::default()).unwrap();
+            assert_eq!(initial_capacity, vec.vec.capacity());
+            assert_eq!(
+                limiter.current_usage(),
+                vec.vec.capacity() * size_of::<T>(),
+                "T={}",
+                size_of::<T>()
+            );
         }
 
-        {
-            let limiter = SharedMemoryLimiter::new(10);
-            let mut vec_u32: LimitedVec<u32> = LimitedVec::new(limiter.clone());
+        vec.drain(1..);
+        assert_eq!(limiter.current_usage(), vec.vec.capacity() * size_of::<T>());
+        vec.drain(..);
+        assert_eq!(limiter.current_usage(), vec.vec.capacity() * size_of::<T>());
 
-            vec_u32.push(1).unwrap();
-            vec_u32.push(2).unwrap();
-            assert_eq!(limiter.current_usage(), 8);
+        for _ in 0..initial_capacity {
+            assert_eq!(initial_capacity, vec.vec.capacity());
+            vec.push(Default::default()).unwrap();
+            assert_eq!(limiter.current_usage(), vec.vec.capacity() * size_of::<T>());
         }
+
+        for _ in 0..initial_capacity {
+            vec.push(Default::default()).unwrap();
+            assert_eq!(initial_capacity * 2, vec.vec.capacity());
+            assert_eq!(limiter.current_usage(), vec.vec.capacity() * size_of::<T>());
+        }
+        (vec, limiter)
     }
 
     #[test]
-    fn max_limit() {
-        let limiter = SharedMemoryLimiter::new(2);
-        let mut vector: LimitedVec<u8> = LimitedVec::new(limiter);
+    fn test_too_low_limit() {
+        let mut vec = LimitedVec::<u8>::new(SharedMemoryLimiter::new(0));
+        assert!(vec.push(0).is_err());
 
-        vector.push(1).unwrap();
-        vector.push(2).unwrap();
+        let mut vec = LimitedVec::<u16>::new(SharedMemoryLimiter::new(1));
+        assert!(vec.push(0).is_err());
 
-        let err = vector.push(3).unwrap_err();
-
-        assert_eq!(err, MemoryLimitExceededError);
+        let mut vec = LimitedVec::<[u8; 257]>::new(SharedMemoryLimiter::new(256));
+        assert!(vec.push([0; 257]).is_err());
     }
 
     #[test]
-    fn drop() {
-        let limiter = SharedMemoryLimiter::new(1);
+    fn test_limit() {
+        let (mut vec, limiter) = test_ty::<u8>();
+        assert!(vec.push(0).is_err());
+        assert!(limiter.current_usage() >= vec.vec.capacity() * size_of::<u8>());
 
-        {
-            let mut vector: LimitedVec<u8> = LimitedVec::new(limiter.clone());
+        let (mut vec, limiter) = test_ty::<u64>();
+        assert!(vec.push(0).is_err());
+        assert!(limiter.current_usage() >= vec.vec.capacity() * size_of::<u64>());
 
-            vector.push(1).unwrap();
-            assert_eq!(limiter.current_usage(), 1);
-        }
+        let (mut vec, limiter) = test_ty::<[u8; 7]>();
+        assert!(vec.push(Default::default()).is_err());
+        assert!(limiter.current_usage() >= vec.vec.capacity() * size_of::<[u8; 7]>());
 
+        let (mut vec, limiter) = test_ty::<[u128; 32]>();
+        assert!(vec.push(Default::default()).is_err());
+        assert!(limiter.current_usage() >= vec.vec.capacity() * size_of::<[u128; 32]>());
+    }
+
+    #[test]
+    fn test_drop() {
+        let (_, limiter) = test_ty::<u8>();
         assert_eq!(limiter.current_usage(), 0);
-    }
 
-    #[test]
-    fn drain() {
-        let limiter = SharedMemoryLimiter::new(10);
-        let mut vector: LimitedVec<u8> = LimitedVec::new(limiter.clone());
-
-        vector.push(1).unwrap();
-        vector.push(2).unwrap();
-        vector.push(3).unwrap();
-        assert_eq!(limiter.current_usage(), 3);
-
-        vector.drain(0..3);
+        let (_, limiter) = test_ty::<u64>();
         assert_eq!(limiter.current_usage(), 0);
 
-        vector.push(1).unwrap();
-        vector.push(2).unwrap();
-        vector.push(3).unwrap();
-        vector.push(4).unwrap();
-        assert_eq!(limiter.current_usage(), 4);
+        let (_, limiter) = test_ty::<[u8; 7]>();
+        assert_eq!(limiter.current_usage(), 0);
 
-        vector.drain(1..=2);
-        assert_eq!(limiter.current_usage(), 2);
+        let (_, limiter) = test_ty::<[u128; 32]>();
+        assert_eq!(limiter.current_usage(), 0);
     }
 }

--- a/src/parser/lexer/actions.rs
+++ b/src/parser/lexer/actions.rs
@@ -33,7 +33,6 @@ impl<S: LexemeSink> StateMachineActions for Lexer<S> {
 
     impl_common_sm_actions!();
 
-    #[inline]
     fn emit_text(&mut self, context: &mut ParserContext<S>, input: &[u8]) -> ActionResult {
         if self.pos() > self.lexeme_start {
             // NOTE: unlike any other tokens (except EOF), text tokens don't have
@@ -53,12 +52,13 @@ impl<S: LexemeSink> StateMachineActions for Lexer<S> {
         Ok(())
     }
 
+    #[inline(never)]
     fn emit_text_and_eof(&mut self, context: &mut ParserContext<S>, input: &[u8]) -> ActionResult {
         self.emit_text(context, input)?;
         self.emit_eof(context, input)
     }
 
-    #[inline]
+    #[inline(never)]
     fn emit_current_token(&mut self, context: &mut ParserContext<S>, input: &[u8]) -> ActionResult {
         let token = self.current_non_tag_content_token.take();
         let lexeme = self.create_lexeme_with_raw_inclusive(
@@ -70,7 +70,7 @@ impl<S: LexemeSink> StateMachineActions for Lexer<S> {
         self.emit_lexeme(context, &lexeme)
     }
 
-    #[inline]
+    #[inline(never)]
     fn emit_tag(&mut self, context: &mut ParserContext<S>, input: &[u8]) -> ActionResult {
         let token = self
             .current_tag_token
@@ -118,7 +118,7 @@ impl<S: LexemeSink> StateMachineActions for Lexer<S> {
         }
     }
 
-    #[inline]
+    #[inline(never)]
     fn emit_current_token_and_eof(
         &mut self,
         context: &mut ParserContext<S>,
@@ -136,7 +136,7 @@ impl<S: LexemeSink> StateMachineActions for Lexer<S> {
     }
 
     /// Emits `<[CDATA[` and such.
-    #[inline]
+    #[inline(never)]
     fn emit_raw_without_token(
         &mut self,
         context: &mut ParserContext<S>,
@@ -151,7 +151,7 @@ impl<S: LexemeSink> StateMachineActions for Lexer<S> {
         self.emit_lexeme(context, &lexeme)
     }
 
-    #[inline]
+    #[inline(never)]
     fn emit_raw_without_token_and_eof(
         &mut self,
         context: &mut ParserContext<S>,

--- a/src/parser/lexer/actions.rs
+++ b/src/parser/lexer/actions.rs
@@ -270,7 +270,11 @@ impl<S: LexemeSink> StateMachineActions for Lexer<S> {
             Some(StartTag { ref mut name, .. } | EndTag { ref mut name, .. }) => {
                 *name = get_token_part_range!(self);
             }
-            _ => unreachable!("Tag should exist at this point"),
+            _ => {
+                return Err(ActionError::RewritingError(RewritingError::internal(
+                    "Tag should exist at this point",
+                )))
+            }
         }
 
         Ok(())
@@ -288,7 +292,7 @@ impl<S: LexemeSink> StateMachineActions for Lexer<S> {
                         ref mut name_hash, ..
                     },
                 ) => name_hash.update(ch),
-                _ => unreachable!("Tag should exist at this point"),
+                _ => debug_assert!(false, "Tag should exist at this point"),
             }
         }
     }

--- a/src/parser/lexer/actions.rs
+++ b/src/parser/lexer/actions.rs
@@ -187,14 +187,14 @@ impl<S: LexemeSink> StateMachineActions for Lexer<S> {
         });
     }
 
-    #[inline]
+    #[cold]
     fn create_doctype(&mut self, _context: &mut ParserContext<S>, _input: &[u8]) {
-        self.current_non_tag_content_token = Some(Doctype {
+        self.current_non_tag_content_token = Some(Doctype(Box::new(DoctypeTokenOutline {
             name: None,
             public_id: None,
             system_id: None,
             force_quirks: false,
-        });
+        })));
     }
 
     #[inline]
@@ -228,39 +228,29 @@ impl<S: LexemeSink> StateMachineActions for Lexer<S> {
 
     #[inline]
     fn set_force_quirks(&mut self, _context: &mut ParserContext<S>, _input: &[u8]) {
-        if let Some(Doctype {
-            ref mut force_quirks,
-            ..
-        }) = self.current_non_tag_content_token
-        {
-            *force_quirks = true;
+        if let Some(Doctype(doctype)) = &mut self.current_non_tag_content_token {
+            doctype.force_quirks = true;
         }
     }
 
     #[inline]
     fn finish_doctype_name(&mut self, _context: &mut ParserContext<S>, _input: &[u8]) {
-        if let Some(Doctype { ref mut name, .. }) = self.current_non_tag_content_token {
-            *name = Some(get_token_part_range!(self));
+        if let Some(Doctype(doctype)) = &mut self.current_non_tag_content_token {
+            doctype.name = Some(get_token_part_range!(self));
         }
     }
 
     #[inline]
     fn finish_doctype_public_id(&mut self, _context: &mut ParserContext<S>, _input: &[u8]) {
-        if let Some(Doctype {
-            ref mut public_id, ..
-        }) = self.current_non_tag_content_token
-        {
-            *public_id = Some(get_token_part_range!(self));
+        if let Some(Doctype(doctype)) = &mut self.current_non_tag_content_token {
+            doctype.public_id = Some(get_token_part_range!(self));
         }
     }
 
     #[inline]
     fn finish_doctype_system_id(&mut self, _context: &mut ParserContext<S>, _input: &[u8]) {
-        if let Some(Doctype {
-            ref mut system_id, ..
-        }) = self.current_non_tag_content_token
-        {
-            *system_id = Some(get_token_part_range!(self));
+        if let Some(Doctype(doctype)) = &mut self.current_non_tag_content_token {
+            doctype.system_id = Some(get_token_part_range!(self));
         }
     }
 

--- a/src/parser/lexer/conditions.rs
+++ b/src/parser/lexer/conditions.rs
@@ -4,14 +4,11 @@ use crate::parser::state_machine::StateMachineConditions;
 impl<S: LexemeSink> StateMachineConditions for Lexer<S> {
     #[inline]
     fn is_appropriate_end_tag(&self) -> bool {
-        match self.current_tag_token {
-            Some(TagTokenOutline::EndTag { name_hash, .. }) => {
-                self.last_start_tag_name_hash == name_hash
-            }
-            _ => {
-                debug_assert!(false, "End tag should exist at this point");
-                false
-            }
+        if let Some(TagTokenOutline::EndTag { name_hash, .. }) = self.current_tag_token {
+            self.last_start_tag_name_hash == name_hash
+        } else {
+            debug_assert!(false, "End tag should exist at this point");
+            false
         }
     }
 

--- a/src/parser/lexer/conditions.rs
+++ b/src/parser/lexer/conditions.rs
@@ -8,7 +8,10 @@ impl<S: LexemeSink> StateMachineConditions for Lexer<S> {
             Some(TagTokenOutline::EndTag { name_hash, .. }) => {
                 self.last_start_tag_name_hash == name_hash
             }
-            _ => unreachable!("End tag should exist at this point"),
+            _ => {
+                debug_assert!(false, "End tag should exist at this point");
+                false
+            }
         }
     }
 

--- a/src/parser/lexer/lexeme/token_outline.rs
+++ b/src/parser/lexer/lexeme/token_outline.rs
@@ -35,17 +35,18 @@ pub(crate) enum TagTokenOutline {
 }
 
 #[derive(Debug)]
+pub struct DoctypeTokenOutline {
+    pub name: Option<Range>,
+    pub public_id: Option<Range>,
+    pub system_id: Option<Range>,
+    pub force_quirks: bool,
+}
+
+#[derive(Debug)]
 pub(crate) enum NonTagContentTokenOutline {
     Text(TextType),
     Comment(Range),
-
-    Doctype {
-        name: Option<Range>,
-        public_id: Option<Range>,
-        system_id: Option<Range>,
-        force_quirks: bool,
-    },
-
+    Doctype(Box<DoctypeTokenOutline>),
     Eof,
 }
 
@@ -69,15 +70,10 @@ impl Align for NonTagContentTokenOutline {
     fn align(&mut self, offset: usize) {
         match self {
             Self::Comment(text) => text.align(offset),
-            Self::Doctype {
-                name,
-                public_id,
-                system_id,
-                ..
-            } => {
-                name.align(offset);
-                public_id.align(offset);
-                system_id.align(offset);
+            Self::Doctype(doctype) => {
+                doctype.name.align(offset);
+                doctype.public_id.align(offset);
+                doctype.system_id.align(offset);
             }
             _ => (),
         }

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -10,7 +10,8 @@ pub(crate) use self::lexer::{
     AttributeBuffer, AttributeOutline, Lexeme, LexemeSink, NonTagContentLexeme,
     NonTagContentTokenOutline, TagLexeme, TagTokenOutline,
 };
-use self::state_machine::{ActionError, ParsingTermination, StateMachine};
+use self::state_machine::StateMachine;
+pub(crate) use self::state_machine::{ActionError, ActionResult};
 pub(crate) use self::tag_scanner::TagHintSink;
 use self::tag_scanner::TagScanner;
 pub use self::tree_builder_simulator::ParsingAmbiguityError;
@@ -71,8 +72,6 @@ impl<S: ParserOutputSink> Parser<S> {
     // It's better to outline it, and let its callers be inlined.
     #[inline(never)]
     pub fn parse(&mut self, input: &[u8], last: bool) -> Result<usize, RewritingError> {
-        use ActionError::*;
-
         let mut parse_result = match self.current_directive {
             ParserDirective::WherePossibleScanForTagsOnly => {
                 self.tag_scanner
@@ -82,18 +81,18 @@ impl<S: ParserOutputSink> Parser<S> {
         };
 
         loop {
-            match parse_result {
-                Err(ParsingTermination::EndOfInput {
+            let unboxed = match parse_result {
+                Ok(unreachable) => match unreachable {},
+                Err(boxed) => *boxed,
+            };
+            match unboxed {
+                ActionError::EndOfInput {
                     consumed_byte_count,
-                }) => {
+                } => {
                     self.context.previously_consumed_byte_count += consumed_byte_count;
                     return Ok(consumed_byte_count);
                 }
-
-                Err(ParsingTermination::ActionError(ParserDirectiveChangeRequired(
-                    new_directive,
-                    sm_bookmark,
-                ))) => {
+                ActionError::ParserDirectiveChangeRequired(new_directive, sm_bookmark) => {
                     self.current_directive = new_directive;
 
                     trace!(@continue_from_bookmark sm_bookmark, self.current_directive, input);
@@ -110,8 +109,10 @@ impl<S: ParserOutputSink> Parser<S> {
                         ),
                     };
                 }
-                Err(ParsingTermination::ActionError(RewritingError(err))) => return Err(err),
-                Ok(unreachable) => match unreachable {},
+                ActionError::RewritingError(err) => return Err(err),
+                ActionError::Internal(err) => {
+                    return Err(RewritingError::ContentHandlerError(err.into()))
+                }
             }
         }
     }

--- a/src/parser/state_machine/mod.rs
+++ b/src/parser/state_machine/mod.rs
@@ -212,7 +212,7 @@ pub(crate) trait StateMachine: StateMachineActions + StateMachineConditions {
         self.run_parsing_loop(context, input, last)
     }
 
-    #[inline]
+    #[cold]
     fn break_on_end_of_input(&mut self, input: &[u8]) -> StateResult {
         let consumed_byte_count = self.get_consumed_byte_count(input);
 

--- a/src/parser/state_machine/syntax_dsl/action.rs
+++ b/src/parser/state_machine/syntax_dsl/action.rs
@@ -1,6 +1,6 @@
 macro_rules! action {
     (| $self:tt, $ctx:tt, $input:ident | > $action_fn:ident ? $($args:expr),* ) => {
-        $self.$action_fn($ctx, $input $(,$args),*).map_err(ParsingTermination::ActionError)?;
+        $self.$action_fn($ctx, $input $(,$args),*)?;
     };
 
     (| $self:tt, $ctx:tt, $input:ident | > $action_fn:ident $($args:expr),* ) => {

--- a/src/parser/tag_scanner/actions.rs
+++ b/src/parser/tag_scanner/actions.rs
@@ -42,11 +42,9 @@ impl<S: TagHintSink> StateMachineActions for TagScanner<S> {
         let tag_start = self
             .tag_start
             .take()
-            .expect("Tag start should be set at this point");
+            .ok_or_else(|| ActionError::internal("Tag start should be set at this point"))?;
 
-        let unhandled_feedback = self
-            .try_apply_tree_builder_feedback(context)
-            .map_err(ActionError::from)?;
+        let unhandled_feedback = self.try_apply_tree_builder_feedback(context)?;
 
         let is_in_end_tag = self.is_in_end_tag;
 
@@ -60,10 +58,7 @@ impl<S: TagHintSink> StateMachineActions for TagScanner<S> {
             );
         }
 
-        match self
-            .emit_tag_hint(context, input, is_in_end_tag)
-            .map_err(ActionError::RewritingError)?
-        {
+        match self.emit_tag_hint(context, input, is_in_end_tag)? {
             ParserDirective::WherePossibleScanForTagsOnly => Ok(()),
             ParserDirective::Lex => {
                 let feedback_directive = self.take_feedback_directive();

--- a/src/parser/tree_builder_simulator/ambiguity_guard.rs
+++ b/src/parser/tree_builder_simulator/ambiguity_guard.rs
@@ -68,7 +68,7 @@ use thiserror::Error;
 /// [`strict`]: ../struct.Settings.html#structfield.strict
 #[derive(Error, Debug, Eq, PartialEq)]
 pub struct ParsingAmbiguityError {
-    on_tag_name: String,
+    on_tag_name: Box<str>,
 }
 
 impl Display for ParsingAmbiguityError {
@@ -98,11 +98,12 @@ impl Display for ParsingAmbiguityError {
 macro_rules! create_assert_for_tags {
     ( $($tag:ident),+ ) => {
         #[cold]
-        fn tag_hash_to_string(tag_name: LocalNameHash) -> String {
-            match tag_name {
-                $(t if t == Tag::$tag => stringify!($tag).to_string().to_lowercase(),)+
-                _ => unreachable!("Error tag name should have a string representation")
-            }
+        fn tag_hash_to_string(tag_name: LocalNameHash) -> Box<str> {
+            let s = match tag_name {
+                $(t if t == Tag::$tag => stringify!($tag),)+
+                _ => "no string representation",
+            };
+            s.to_ascii_lowercase().into_boxed_str()
         }
 
         #[inline]

--- a/src/parser/tree_builder_simulator/mod.rs
+++ b/src/parser/tree_builder_simulator/mod.rs
@@ -205,10 +205,14 @@ impl TreeBuilderSimulator {
     fn leave_ns(&mut self) -> TreeBuilderFeedback {
         self.ns_stack.pop();
 
-        self.current_ns = *self
-            .ns_stack
-            .last()
-            .expect("Namespace stack should always have at least one item");
+        let Some(item) = self.ns_stack.last() else {
+            debug_assert!(
+                false,
+                "Namespace stack should always have at least one item"
+            );
+            return TreeBuilderFeedback::None;
+        };
+        self.current_ns = *item;
 
         TreeBuilderFeedback::SetAllowCdata(self.current_ns != Namespace::Html)
     }

--- a/src/parser/tree_builder_simulator/mod.rs
+++ b/src/parser/tree_builder_simulator/mod.rs
@@ -53,7 +53,10 @@ macro_rules! expect_tag {
     ($lexeme:expr, $tag_pat:pat => $action:expr) => {
         match *$lexeme.token_outline() {
             $tag_pat => $action,
-            _ => unreachable!("Got unexpected tag type"),
+            _ => {
+                debug_assert!(false, "Got unexpected tag type");
+                return TreeBuilderFeedback::None;
+            }
         }
     };
 }

--- a/src/rewritable_units/tokens/capturer/to_token.rs
+++ b/src/rewritable_units/tokens/capturer/to_token.rs
@@ -67,34 +67,31 @@ impl ToToken for NonTagContentLexeme<'_> {
         capture_flags: &mut TokenCaptureFlags,
         encoding: &'static Encoding,
     ) -> ToTokenResult<'_> {
-        match *self.token_outline() {
+        match self.token_outline() {
             Some(NonTagContentTokenOutline::Text(text_type))
                 if capture_flags.contains(TokenCaptureFlags::TEXT) =>
             {
-                ToTokenResult::Text(text_type)
+                ToTokenResult::Text(*text_type)
             }
 
             Some(NonTagContentTokenOutline::Comment(text))
                 if capture_flags.contains(TokenCaptureFlags::COMMENTS) =>
             {
                 ToTokenResult::Token(Comment::new_token(
-                    self.part(text),
+                    self.part(*text),
                     self.spanned().into(),
                     encoding,
                 ))
             }
 
-            Some(NonTagContentTokenOutline::Doctype {
-                name,
-                public_id,
-                system_id,
-                force_quirks,
-            }) if capture_flags.contains(TokenCaptureFlags::DOCTYPES) => {
+            Some(NonTagContentTokenOutline::Doctype(doctype))
+                if capture_flags.contains(TokenCaptureFlags::DOCTYPES) =>
+            {
                 ToTokenResult::Token(Doctype::new_token(
-                    self.opt_part(name),
-                    self.opt_part(public_id),
-                    self.opt_part(system_id),
-                    force_quirks,
+                    self.opt_part(doctype.name),
+                    self.opt_part(doctype.public_id),
+                    self.opt_part(doctype.system_id),
+                    doctype.force_quirks,
                     false, // removed
                     self.spanned(),
                     encoding,

--- a/src/rewriter/mod.rs
+++ b/src/rewriter/mod.rs
@@ -85,6 +85,16 @@ pub enum RewritingError {
     ContentHandlerError(Box<dyn StdError + Send + Sync + 'static>),
 }
 
+impl RewritingError {
+    #[cold]
+    #[inline(never)]
+    #[cfg_attr(debug_assertions, track_caller)]
+    pub(crate) fn internal(error: &'static str) -> Self {
+        debug_assert!(false, "{error}");
+        Self::ContentHandlerError(error.into())
+    }
+}
+
 /// A streaming HTML rewriter.
 ///
 /// # Example

--- a/src/rewriter/mod.rs
+++ b/src/rewriter/mod.rs
@@ -85,16 +85,6 @@ pub enum RewritingError {
     ContentHandlerError(Box<dyn StdError + Send + Sync + 'static>),
 }
 
-impl RewritingError {
-    #[cold]
-    #[inline(never)]
-    #[cfg_attr(debug_assertions, track_caller)]
-    pub(crate) fn internal(error: &'static str) -> Self {
-        debug_assert!(false, "{error}");
-        Self::ContentHandlerError(error.into())
-    }
-}
-
 /// A streaming HTML rewriter.
 ///
 /// # Example

--- a/src/transform_stream/dispatcher.rs
+++ b/src/transform_stream/dispatcher.rs
@@ -276,7 +276,9 @@ where
                 } => {
                     get_flags_from_aux_info_res!(aux_info_req, &attributes, self_closing)
                 }
-                _ => unreachable!("Tag should be a start tag at this point"),
+                _ => Err(RewritingError::internal(
+                    "Tag should be a start tag at this point",
+                )),
             },
 
             // NOTE: tag hint hasn't been produced for the tag, because
@@ -396,7 +398,7 @@ where
             Some(NonTagContentTokenOutline::Text(_)) => {}
             // when it's None, it still needs a flush for CDATA
             _ => self.flush_pending_captured_text()?,
-        }
+        };
         self.try_produce_token_from_lexeme(lexeme)
     }
 }


### PR DESCRIPTION
I've reduced size of frequently-returned types, especially results in the state machine. This made aggressive inlining less necessary, so I've got code size reduction.

I've also removed potentially-panicking branches from hot code, which also reduced code bloat.

Overall, it's a ~20% code size reduction in the lol_html crate. Less for the whole binary, because encoding_rs is big.