### PR TITLE
Improve type generation in js-api

### DIFF
--- a/js-api/src/document_end.rs
+++ b/js-api/src/document_end.rs
@@ -11,6 +11,7 @@ impl DocumentEnd {
     pub fn append(
         &mut self,
         content: &str,
+        #[wasm_bindgen(js_name = "html")]
         content_type: Option<ContentTypeOptions>,
     ) -> Result<(), JsValue> {
         self.0

--- a/js-api/src/element.rs
+++ b/js-api/src/element.rs
@@ -105,6 +105,7 @@ impl Element {
     pub fn prepend(
         &mut self,
         content: &str,
+        #[wasm_bindgen(js_name = "html")]
         content_type: Option<ContentTypeOptions>,
     ) -> Result<(), JsValue> {
         self.0
@@ -115,6 +116,7 @@ impl Element {
     pub fn append(
         &mut self,
         content: &str,
+        #[wasm_bindgen(js_name = "html")]
         content_type: Option<ContentTypeOptions>,
     ) -> Result<(), JsValue> {
         self.0
@@ -126,6 +128,7 @@ impl Element {
     pub fn set_inner_content(
         &mut self,
         content: &str,
+        #[wasm_bindgen(js_name = "html")]
         content_type: Option<ContentTypeOptions>,
     ) -> Result<(), JsValue> {
         self.0

--- a/js-api/src/handlers.rs
+++ b/js-api/src/handlers.rs
@@ -34,8 +34,17 @@ macro_rules! make_handler {
     }};
 }
 
+#[wasm_bindgen(typescript_custom_section)]
+const INTERFACE_ELEMENT_CONTENT_HANDLERS: &'static str = r#"
+export interface ElementContentHandlers {
+    element?: (element: Element) => void;
+    comments?: (comment: Comment) => void;
+    text?: (textChunk: TextChunk) => void;
+}"#;
+
 #[wasm_bindgen]
 extern "C" {
+    #[wasm_bindgen(typescript_type = "ElementContentHandlers")]
     pub type ElementContentHandlers;
 
     #[wasm_bindgen(method, getter)]
@@ -68,8 +77,18 @@ impl IntoNative<NativeElementContentHandlers<'static>> for ElementContentHandler
     }
 }
 
+#[wasm_bindgen(typescript_custom_section)]
+const INTERFACE_DOCUMENT_CONTENT_HANDLERS: &'static str = r#"
+export interface DocumentContentHandlers {
+    doctype?: (doctype: Doctype) => void;
+    comments?: (comment: Comment) => void;
+    text?: (textChunk: TextChunk) => void;
+    end?: (end: DocumentEnd) => void;
+}"#;
+
 #[wasm_bindgen]
 extern "C" {
+    #[wasm_bindgen(typescript_type = "DocumentContentHandlers")]
     pub type DocumentContentHandlers;
 
     #[wasm_bindgen(method, getter)]

--- a/js-api/src/html_rewriter.rs
+++ b/js-api/src/html_rewriter.rs
@@ -50,7 +50,11 @@ pub struct HTMLRewriter(RewriterState);
 #[wasm_bindgen]
 impl HTMLRewriter {
     #[wasm_bindgen(constructor)]
-    pub fn new(encoding: String, output_sink: &JsFunction) -> JsResult<Self> {
+    pub fn new(
+        encoding: String,
+        #[wasm_bindgen(unchecked_param_type = "(chunk: Uint8Array) => void")]
+        output_sink: &JsFunction
+    ) -> JsResult<Self> {
         let encoding = Encoding::for_label(encoding.as_bytes())
             .and_then(AsciiCompatibleEncoding::new)
             .ok_or_else(|| JsError::new("Invalid encoding"))?;

--- a/js-api/src/lib.rs
+++ b/js-api/src/lib.rs
@@ -91,6 +91,7 @@ trait IntoNative<T> {
 
 #[wasm_bindgen]
 extern "C" {
+    #[wasm_bindgen(typescript_type = "boolean")]
     pub type ContentTypeOptions;
 
     #[wasm_bindgen(method, getter)]
@@ -117,6 +118,7 @@ macro_rules! impl_mutations {
             pub fn before(
                 &mut self,
                 content: &str,
+                #[wasm_bindgen(js_name = "html")]
                 content_type: Option<ContentTypeOptions>,
             ) -> Result<(), JsValue> {
                 self.0
@@ -127,6 +129,7 @@ macro_rules! impl_mutations {
             pub fn after(
                 &mut self,
                 content: &str,
+                #[wasm_bindgen(js_name = "html")]
                 content_type: Option<ContentTypeOptions>,
             ) -> Result<(), JsValue> {
                 self.0
@@ -137,6 +140,7 @@ macro_rules! impl_mutations {
             pub fn replace(
                 &mut self,
                 content: &str,
+                #[wasm_bindgen(js_name = "html")]
                 content_type: Option<ContentTypeOptions>,
             ) -> Result<(), JsValue> {
                 self.0

--- a/js-api/src/text_chunk.rs
+++ b/js-api/src/text_chunk.rs
@@ -23,7 +23,7 @@ impl TextChunk {
     /// Returns a JS array `[start, end]` with byte offsets relative to the start of the document.
     ///
     /// The byte offsets are incompatible with JS's char code indices.
-    #[wasm_bindgen(getter=sourceLocationBytes)]
+    #[wasm_bindgen(getter=sourceLocationBytes, unchecked_return_type="[number, number]")]
     pub fn source_location_bytes(&self) -> JsResult<JsValue> {
         Ok(location_to_js(self.0.get()?.source_location()))
     }


### PR DESCRIPTION
Add manual hints to generate more accurate type information.

<details>
<summary>Diff of <code>lol_html.d.ts</code> </summary>

```diff
--- type.orig.d.ts
+++ type.new.d.ts
@@ -1,11 +1,26 @@
 /* tslint:disable */
 /* eslint-disable */
+
+export interface ElementContentHandlers {
+    element?: (element: Element) => void;
+    comments?: (comment: Comment) => void;
+    text?: (textChunk: TextChunk) => void;
+}
+
+
+export interface DocumentContentHandlers {
+    doctype?: (doctype: Doctype) => void;
+    comments?: (comment: Comment) => void;
+    text?: (textChunk: TextChunk) => void;
+    end?: (end: DocumentEnd) => void;
+}
+
 export class Comment {
   private constructor();
   free(): void;
-  before(content: string, content_type?: any | null): void;
-  after(content: string, content_type?: any | null): void;
-  replace(content: string, content_type?: any | null): void;
+  before(content: string, html?: boolean | null): void;
+  after(content: string, html?: boolean | null): void;
+  replace(content: string, html?: boolean | null): void;
   remove(): void;
   readonly removed: boolean;
   readonly text: string;
@@ -26,22 +41,22 @@
 export class DocumentEnd {
   private constructor();
   free(): void;
-  append(content: string, content_type?: any | null): void;
+  append(content: string, html?: boolean | null): void;
 }
 export class Element {
   private constructor();
   free(): void;
-  before(content: string, content_type?: any | null): void;
-  after(content: string, content_type?: any | null): void;
-  replace(content: string, content_type?: any | null): void;
+  before(content: string, html?: boolean | null): void;
+  after(content: string, html?: boolean | null): void;
+  replace(content: string, html?: boolean | null): void;
   remove(): void;
   getAttribute(name: string): string | undefined;
   hasAttribute(name: string): boolean;
   setAttribute(name: string, value: string): void;
   removeAttribute(name: string): void;
-  prepend(content: string, content_type?: any | null): void;
-  append(content: string, content_type?: any | null): void;
-  setInnerContent(content: string, content_type?: any | null): void;
+  prepend(content: string, html?: boolean | null): void;
+  append(content: string, html?: boolean | null): void;
+  setInnerContent(content: string, html?: boolean | null): void;
   removeAndKeepContent(): void;
   onEndTag(handler: Function): void;
   readonly removed: boolean;
@@ -59,9 +74,9 @@
 export class EndTag {
   private constructor();
   free(): void;
-  before(content: string, content_type?: any | null): void;
-  after(content: string, content_type?: any | null): void;
-  replace(content: string, content_type?: any | null): void;
+  before(content: string, html?: boolean | null): void;
+  after(content: string, html?: boolean | null): void;
+  replace(content: string, html?: boolean | null): void;
   remove(): void;
   readonly removed: boolean;
   readonly name: string;
@@ -74,18 +89,18 @@
 }
 export class HTMLRewriter {
   free(): void;
-  constructor(encoding: string, output_sink: Function);
-  on(selector: string, handlers: any): void;
-  onDocument(handlers: any): void;
+  constructor(encoding: string, output_sink: (chunk: Uint8Array) => void);
+  on(selector: string, handlers: ElementContentHandlers): void;
+  onDocument(handlers: DocumentContentHandlers): void;
   write(chunk: Uint8Array): void;
   end(): void;
 }
 export class TextChunk {
   private constructor();
   free(): void;
-  before(content: string, content_type?: any | null): void;
-  after(content: string, content_type?: any | null): void;
-  replace(content: string, content_type?: any | null): void;
+  before(content: string, html?: boolean | null): void;
+  after(content: string, html?: boolean | null): void;
+  replace(content: string, html?: boolean | null): void;
   remove(): void;
   readonly removed: boolean;
   /**
@@ -98,5 +113,5 @@
    *
    * The byte offsets are incompatible with JS's char code indices.
    */
-  readonly sourceLocationBytes: any;
+  readonly sourceLocationBytes: [number, number];
 }
```
</details>