### PR TITLE
Reallocs

### DIFF
--- a/src/base/bytes.rs
+++ b/src/base/bytes.rs
@@ -21,47 +21,36 @@ pub(crate) struct Bytes<'b>(&'b [u8]);
 pub struct BytesCow<'b>(Cow<'b, [u8]>);
 
 impl<'b> BytesCow<'b> {
-    #[inline]
-    pub fn from_str(string: &'b str, encoding: &'static Encoding) -> Self {
-        encoding.encode(string).0.into()
-    }
-
-    /// Same as `BytesCow::from_str(&string).into_owned()`, but avoids copying in the common case where
-    /// the output and input encodings are the same.
-    pub fn from_string<'tmp>(
-        string: impl Into<Cow<'tmp, str>>,
-        encoding: &'static Encoding,
-    ) -> BytesCow<'static> {
-        let string = string.into();
-        BytesCow(Cow::Owned(match encoding.encode(string.as_ref()).0 {
-            Cow::Owned(bytes) => bytes,
-            Cow::Borrowed(_) => string.into_owned().into_bytes(),
-        }))
-    }
-
-    #[inline]
-    pub(crate) fn from_str_without_replacements(
+    pub(crate) fn borrow_from_str_without_replacements(
         string: impl Into<Cow<'b, str>>,
         encoding: &'static Encoding,
     ) -> Result<Self, HasReplacementsError> {
+        let (has_replacements, bytes) = Self::borrowed(string, encoding);
+        if !has_replacements {
+            Ok(bytes)
+        } else {
+            Err(HasReplacementsError)
+        }
+    }
+
+    fn borrowed(string: impl Into<Cow<'b, str>>, encoding: &'static Encoding) -> (bool, Self) {
         let string = string.into();
         let (res, _, has_replacements) = encoding.encode(&string);
 
-        if has_replacements {
-            Err(HasReplacementsError)
-        } else {
-            Ok(Self(match res {
+        (
+            has_replacements,
+            Self(match res {
                 Cow::Borrowed(_) => match string {
                     Cow::Borrowed(s) => Cow::Borrowed(s.as_bytes()),
                     Cow::Owned(s) => Cow::Owned(s.into_bytes()),
                 },
                 Cow::Owned(bytes) => Cow::Owned(bytes),
-            }))
-        }
+            }),
+        )
     }
 
     #[inline]
-    pub fn into_owned(self) -> BytesCow<'static> {
+    pub(crate) fn into_owned(self) -> BytesCow<'static> {
         BytesCow(Cow::Owned(self.0.into_owned()))
     }
 
@@ -70,12 +59,48 @@ impl<'b> BytesCow<'b> {
         Bytes(&self.0)
     }
 
-    pub fn as_string(&self, encoding: &'static Encoding) -> String {
+    pub(crate) fn as_string(&self, encoding: &'static Encoding) -> String {
         self.as_ref().as_string(encoding)
     }
 
-    pub fn as_lowercase_string(&self, encoding: &'static Encoding) -> String {
+    pub(crate) fn as_lowercase_string(&self, encoding: &'static Encoding) -> String {
         self.as_ref().as_lowercase_string(encoding)
+    }
+}
+
+impl BytesCow<'static> {
+    #[inline]
+    pub(crate) fn owned_from_str<'copied>(
+        string: impl Into<Cow<'copied, str>>,
+        encoding: &'static Encoding,
+    ) -> Self {
+        Self::owned(string, encoding).1
+    }
+
+    #[inline]
+    pub(crate) fn owned_from_str_without_replacements<'copied>(
+        string: impl Into<Cow<'copied, str>>,
+        encoding: &'static Encoding,
+    ) -> Result<Self, HasReplacementsError> {
+        let (has_replacements, bytes) = Self::owned(string, encoding);
+        if !has_replacements {
+            Ok(bytes)
+        } else {
+            Err(HasReplacementsError)
+        }
+    }
+
+    fn owned<'tmp>(string: impl Into<Cow<'tmp, str>>, encoding: &'static Encoding) -> (bool, Self) {
+        let string = string.into();
+        let (res, _, has_replacements) = encoding.encode(&string);
+
+        (
+            has_replacements,
+            BytesCow(Cow::Owned(match res {
+                Cow::Owned(bytes) => bytes,
+                Cow::Borrowed(_) => string.into_owned().into_bytes(),
+            })),
+        )
     }
 }
 

--- a/src/base/bytes.rs
+++ b/src/base/bytes.rs
@@ -7,8 +7,7 @@ use std::str;
 
 /// An error used to indicate that an encoded string has replacements and can't be converted losslessly.
 #[derive(Debug, Default, PartialEq, Eq, PartialOrd, Ord)]
-#[allow(unnameable_types)] // accidentally exposed via `tag.set_name()`
-pub struct HasReplacementsError;
+pub(crate) struct HasReplacementsError;
 
 /// A thin wrapper around byte slice with handy APIs attached
 #[derive(Copy, Clone, PartialEq, Eq, Hash, Default)]
@@ -17,7 +16,7 @@ pub(crate) struct Bytes<'b>(&'b [u8]);
 
 /// A thin wrapper around either byte slice or owned bytes with some handy APIs attached
 #[derive(Clone, PartialEq, Eq, Hash)]
-#[allow(unnameable_types)] // accidentally exposed via `tag.set_name()`
+#[allow(unnameable_types)] // it's pub only for integration test
 #[repr(transparent)]
 pub struct BytesCow<'b>(Cow<'b, [u8]>);
 
@@ -41,7 +40,7 @@ impl<'b> BytesCow<'b> {
     }
 
     #[inline]
-    pub fn from_str_without_replacements(
+    pub(crate) fn from_str_without_replacements(
         string: impl Into<Cow<'b, str>>,
         encoding: &'static Encoding,
     ) -> Result<Self, HasReplacementsError> {

--- a/src/html/local_name.rs
+++ b/src/html/local_name.rs
@@ -170,7 +170,7 @@ impl<'i> LocalName<'i> {
         let hash = LocalNameHash::from(&*string);
 
         if hash.is_empty() {
-            BytesCow::from_str_without_replacements(string, encoding).map(LocalName::Bytes)
+            BytesCow::borrow_from_str_without_replacements(string, encoding).map(LocalName::Bytes)
         } else {
             Ok(LocalName::Hash(hash))
         }

--- a/src/rewritable_units/element.rs
+++ b/src/rewritable_units/element.rs
@@ -88,9 +88,8 @@ impl<'rewriter, 'input_token, H: HandlerTypes> Element<'rewriter, 'input_token, 
                     // encoding then encoding_rs replaces it with a numeric
                     // character reference. Character references are not
                     // supported in tag names, so we need to bail.
-                    BytesCow::from_str_without_replacements(name, self.encoding)
+                    BytesCow::owned_from_str_without_replacements(name, self.encoding)
                         .map_err(|_| TagNameError::UnencodableCharacter)
-                        .map(BytesCow::into_owned)
                 }
             }
             None => Err(TagNameError::Empty),

--- a/src/rewritable_units/tokens/attributes.rs
+++ b/src/rewritable_units/tokens/attributes.rs
@@ -78,9 +78,8 @@ impl<'i> Attribute<'i> {
             // encoding then encoding_rs replaces it with a numeric
             // character reference. Character references are not
             // supported in attribute names, so we need to bail.
-            BytesCow::from_str_without_replacements(name, encoding)
+            BytesCow::owned_from_str_without_replacements(name, encoding)
                 .map_err(|_| AttributeNameError::UnencodableCharacter)
-                .map(BytesCow::into_owned)
         }
     }
 
@@ -107,7 +106,7 @@ impl<'i> Attribute<'i> {
 
     #[inline]
     fn set_value(&mut self, value: &str) {
-        self.value = BytesCow::from_str(value, self.encoding).into_owned();
+        self.value = BytesCow::owned_from_str(value, self.encoding);
         self.raw = None;
     }
 }
@@ -208,7 +207,7 @@ impl<'i> Attributes<'i> {
             None => {
                 items.push(Attribute {
                     name,
-                    value: BytesCow::from_str(value, encoding).into_owned(),
+                    value: BytesCow::owned_from_str(value, encoding),
                     raw: None,
                     encoding,
                 });

--- a/src/rewritable_units/tokens/comment.rs
+++ b/src/rewritable_units/tokens/comment.rs
@@ -75,9 +75,9 @@ impl<'i> Comment<'i> {
             // encoding then encoding_rs replaces it with a numeric
             // character reference. Character references are not
             // supported in comments, so we need to bail.
-            match BytesCow::from_str_without_replacements(text, self.encoding) {
+            match BytesCow::owned_from_str_without_replacements(text, self.encoding) {
                 Ok(text) => {
-                    self.text = text.into_owned();
+                    self.text = text;
                     self.raw.set_modified();
 
                     Ok(())

--- a/src/rewritable_units/tokens/end_tag.rs
+++ b/src/rewritable_units/tokens/end_tag.rs
@@ -78,7 +78,7 @@ impl<'i> EndTag<'i> {
     /// the rest of the generated document will be parsed differently than during rewriting.
     #[doc(hidden)]
     pub fn set_name_str(&mut self, name: String) {
-        self.set_name_raw(BytesCow::from_string(name, self.encoding));
+        self.set_name_raw(BytesCow::owned_from_str(name, self.encoding));
     }
 
     /// Inserts `content` before the end tag.

--- a/src/rewritable_units/tokens/end_tag.rs
+++ b/src/rewritable_units/tokens/end_tag.rs
@@ -52,14 +52,6 @@ impl<'i> EndTag<'i> {
         self.name.as_string(self.encoding)
     }
 
-    #[doc(hidden)]
-    #[deprecated(
-        note = "this method won't convert the string encoding, and the type of the argument is a private implementation detail. Use set_name_str() instead"
-    )]
-    pub fn set_name(&mut self, name: BytesCow<'static>) {
-        self.set_name_raw(name);
-    }
-
     /// Sets the name of the tag.
     pub(crate) fn set_name_raw(&mut self, name: BytesCow<'static>) {
         self.name = name;
@@ -73,6 +65,18 @@ impl<'i> EndTag<'i> {
     /// The name must have a valid syntax, and the closing tag must be valid in its context.
     /// The parser will not take the new name into account, so if the new tag alters the structure of the document,
     /// the rest of the generated document will be parsed differently than during rewriting.
+    pub fn set_name(&mut self, name: impl Into<String>) {
+        self.set_name_str(name.into());
+    }
+
+    /// Sets the name of the tag only. To rename the element, prefer [`Element::set_tag_name()`][crate::html_content::Element::set_tag_name].
+    ///
+    /// The name will be converted to the document's encoding.
+    ///
+    /// The name must have a valid syntax, and the closing tag must be valid in its context.
+    /// The parser will not take the new name into account, so if the new tag alters the structure of the document,
+    /// the rest of the generated document will be parsed differently than during rewriting.
+    #[doc(hidden)]
     pub fn set_name_str(&mut self, name: String) {
         self.set_name_raw(BytesCow::from_string(name, self.encoding));
     }

--- a/src/rewritable_units/tokens/start_tag.rs
+++ b/src/rewritable_units/tokens/start_tag.rs
@@ -75,12 +75,8 @@ impl<'input_token> StartTag<'input_token> {
     /// The new tag name must be in the same namespace, have the same content model, and be valid in its location.
     /// Otherwise change of the tag name may cause the resulting document to be parsed in an unexpected way,
     /// out of sync with this library.
-    #[doc(hidden)]
-    #[deprecated(
-        note = "this method won't convert the string encoding, and the type of the argument is a private implementation detail. Use Element::set_tag_name() instead"
-    )]
-    pub fn set_name(&mut self, name: BytesCow<'static>) {
-        self.set_name_raw(name);
+    pub fn set_name(&mut self, name: impl Into<String>) {
+        self.set_name_raw(BytesCow::from_string(name.into(), self.encoding()));
     }
 
     /// Returns the [namespace URI] of the tag's element.

--- a/src/rewritable_units/tokens/start_tag.rs
+++ b/src/rewritable_units/tokens/start_tag.rs
@@ -76,7 +76,7 @@ impl<'input_token> StartTag<'input_token> {
     /// Otherwise change of the tag name may cause the resulting document to be parsed in an unexpected way,
     /// out of sync with this library.
     pub fn set_name(&mut self, name: impl Into<String>) {
-        self.set_name_raw(BytesCow::from_string(name.into(), self.encoding()));
+        self.set_name_raw(BytesCow::owned_from_str(name.into(), self.encoding()));
     }
 
     /// Returns the [namespace URI] of the tag's element.

--- a/src/selectors_vm/compiler.rs
+++ b/src/selectors_vm/compiler.rs
@@ -113,7 +113,7 @@ fn compile_literal(
     encoding: &'static Encoding,
     lit: &str,
 ) -> Result<BytesOwned, HasReplacementsError> {
-    Ok(BytesCow::from_str_without_replacements(lit, encoding)?.into())
+    Ok(BytesCow::owned_from_str_without_replacements(lit, encoding)?.into())
 }
 
 #[inline]

--- a/src/selectors_vm/compiler.rs
+++ b/src/selectors_vm/compiler.rs
@@ -33,11 +33,11 @@ pub(crate) struct AttrExprOperands {
 
 impl Expr<OnTagNameExpr> {
     #[inline]
-    pub fn compile_expr<F: Fn(&SelectorState<'_>, &LocalName<'_>) -> bool + Send + 'static>(
-        &self,
+    fn compile_expr<F: Fn(&SelectorState<'_>, &LocalName<'_>) -> bool + Send + 'static>(
+        negation: bool,
         f: F,
     ) -> CompiledLocalNameExpr {
-        if self.negation {
+        if negation {
             Box::new(move |s, a| !f(s, a))
         } else {
             Box::new(f)
@@ -47,7 +47,7 @@ impl Expr<OnTagNameExpr> {
 
 trait Compilable {
     fn compile(
-        &self,
+        self,
         encoding: &'static Encoding,
         exprs: &mut ExprSet,
         enable_nth_of_type: &mut bool,
@@ -56,30 +56,33 @@ trait Compilable {
 
 impl Compilable for Expr<OnTagNameExpr> {
     fn compile(
-        &self,
+        self,
         encoding: &'static Encoding,
         exprs: &mut ExprSet,
         enable_nth_of_type: &mut bool,
     ) {
-        let expr = match &self.simple_expr {
-            OnTagNameExpr::ExplicitAny => self.compile_expr(|_, _| true),
-            OnTagNameExpr::Unmatchable => self.compile_expr(|_, _| false),
+        let neg = self.negation;
+        let expr = match self.simple_expr {
+            OnTagNameExpr::ExplicitAny => Self::compile_expr(neg, |_, _| true),
+            OnTagNameExpr::Unmatchable => Self::compile_expr(neg, |_, _| false),
             OnTagNameExpr::LocalName(local_name) => {
-                match LocalName::from_str_without_replacements(&**local_name, encoding)
+                match LocalName::from_str_without_replacements(local_name.into_string(), encoding)
                     .map(LocalName::into_owned)
                 {
-                    Ok(local_name) => self.compile_expr(move |_, actual| *actual == local_name),
+                    Ok(local_name) => {
+                        Self::compile_expr(neg, move |_, actual| *actual == local_name)
+                    }
                     // NOTE: selector value can't be converted to the given encoding, so
                     // it won't ever match.
-                    Err(_) => self.compile_expr(|_, _| false),
+                    Err(_) => Self::compile_expr(neg, |_, _| false),
                 }
             }
-            &OnTagNameExpr::NthChild(nth) => {
-                self.compile_expr(move |state, _| state.cumulative.is_nth(nth))
+            OnTagNameExpr::NthChild(nth) => {
+                Self::compile_expr(neg, move |state, _| state.cumulative.is_nth(nth))
             }
-            &OnTagNameExpr::NthOfType(nth) => {
+            OnTagNameExpr::NthOfType(nth) => {
                 *enable_nth_of_type = true;
-                self.compile_expr(move |state, _| {
+                Self::compile_expr(neg, move |state, _| {
                     state
                         .typed
                         .expect("Counter for type required at this point")
@@ -94,13 +97,11 @@ impl Compilable for Expr<OnTagNameExpr> {
 
 impl Expr<OnAttributesExpr> {
     #[inline]
-    pub fn compile_expr<
-        F: Fn(&SelectorState<'_>, &AttributeMatcher<'_>) -> bool + Send + 'static,
-    >(
-        &self,
+    fn compile_expr<F: Fn(&SelectorState<'_>, &AttributeMatcher<'_>) -> bool + Send + 'static>(
+        negation: bool,
         f: F,
     ) -> CompiledAttributeExpr {
-        if self.negation {
+        if negation {
             Box::new(move |s, a| !f(s, a))
         } else {
             Box::new(f)
@@ -111,24 +112,25 @@ impl Expr<OnAttributesExpr> {
 #[inline]
 fn compile_literal(
     encoding: &'static Encoding,
-    lit: &str,
+    lit: Box<str>,
 ) -> Result<BytesOwned, HasReplacementsError> {
-    Ok(BytesCow::owned_from_str_without_replacements(lit, encoding)?.into())
+    Ok(BytesCow::owned_from_str_without_replacements(lit.into_string(), encoding)?.into())
 }
 
 #[inline]
 fn compile_literal_lowercase(
     encoding: &'static Encoding,
-    lit: &str,
+    mut lit: Box<str>,
 ) -> Result<BytesOwned, HasReplacementsError> {
-    compile_literal(encoding, &lit.to_ascii_lowercase())
+    lit.make_ascii_lowercase();
+    compile_literal(encoding, lit)
 }
 
 #[inline]
 fn compile_operands(
     encoding: &'static Encoding,
-    name: &str,
-    value: &str,
+    name: Box<str>,
+    value: Box<str>,
 ) -> Result<(BytesOwned, BytesOwned), HasReplacementsError> {
     Ok((
         compile_literal_lowercase(encoding, name)?,
@@ -137,54 +139,55 @@ fn compile_operands(
 }
 
 impl Compilable for Expr<OnAttributesExpr> {
-    fn compile(&self, encoding: &'static Encoding, exprs: &mut ExprSet, _: &mut bool) {
-        let expr_result =
-            match &self.simple_expr {
-                OnAttributesExpr::Id(id) => compile_literal(encoding, id)
-                    .map(|id| self.compile_expr(move |_, m| m.has_id(&id))),
+    fn compile(self, encoding: &'static Encoding, exprs: &mut ExprSet, _: &mut bool) {
+        let neg = self.negation;
+        let expr_result = match self.simple_expr {
+            OnAttributesExpr::Id(id) => compile_literal(encoding, id)
+                .map(|id| Self::compile_expr(neg, move |_, m| m.has_id(&id))),
 
-                OnAttributesExpr::Class(class) => compile_literal(encoding, class)
-                    .map(|class| self.compile_expr(move |_, m| m.has_class(&class))),
+            OnAttributesExpr::Class(class) => compile_literal(encoding, class)
+                .map(|class| Self::compile_expr(neg, move |_, m| m.has_class(&class))),
 
-                OnAttributesExpr::AttributeExists(name) => compile_literal(encoding, name)
-                    .map(|name| self.compile_expr(move |_, m| m.has_attribute(&name))),
+            OnAttributesExpr::AttributeExists(name) => compile_literal(encoding, name)
+                .map(|name| Self::compile_expr(neg, move |_, m| m.has_attribute(&name))),
 
-                &OnAttributesExpr::AttributeComparisonExpr(AttributeComparisonExpr {
-                    ref name,
-                    ref value,
+            OnAttributesExpr::AttributeComparisonExpr(AttributeComparisonExpr {
+                name,
+                value,
+                case_sensitivity,
+                operator,
+            }) => compile_operands(encoding, name, value).map(move |(name, value)| {
+                let operands = AttrExprOperands {
+                    name,
+                    value,
                     case_sensitivity,
-                    operator,
-                }) => compile_operands(encoding, name, value).map(move |(name, value)| {
-                    let operands = AttrExprOperands {
-                        name,
-                        value,
-                        case_sensitivity,
-                    };
-                    match operator {
-                        AttrSelectorOperator::Equal => {
-                            self.compile_expr(move |_, m| m.attr_eq(&operands))
-                        }
-                        AttrSelectorOperator::Includes => self
-                            .compile_expr(move |_, m| m.matches_splitted_by_whitespace(&operands)),
-                        AttrSelectorOperator::DashMatch => {
-                            self.compile_expr(move |_, m| m.has_dash_matching_attr(&operands))
-                        }
-                        AttrSelectorOperator::Prefix => {
-                            self.compile_expr(move |_, m| m.has_attr_with_prefix(&operands))
-                        }
-                        AttrSelectorOperator::Suffix => {
-                            self.compile_expr(move |_, m| m.has_attr_with_suffix(&operands))
-                        }
-                        AttrSelectorOperator::Substring => {
-                            self.compile_expr(move |_, m| m.has_attr_with_substring(&operands))
-                        }
+                };
+                match operator {
+                    AttrSelectorOperator::Equal => {
+                        Self::compile_expr(neg, move |_, m| m.attr_eq(&operands))
                     }
-                }),
-            };
+                    AttrSelectorOperator::Includes => Self::compile_expr(neg, move |_, m| {
+                        m.matches_splitted_by_whitespace(&operands)
+                    }),
+                    AttrSelectorOperator::DashMatch => {
+                        Self::compile_expr(neg, move |_, m| m.has_dash_matching_attr(&operands))
+                    }
+                    AttrSelectorOperator::Prefix => {
+                        Self::compile_expr(neg, move |_, m| m.has_attr_with_prefix(&operands))
+                    }
+                    AttrSelectorOperator::Suffix => {
+                        Self::compile_expr(neg, move |_, m| m.has_attr_with_suffix(&operands))
+                    }
+                    AttrSelectorOperator::Substring => {
+                        Self::compile_expr(neg, move |_, m| m.has_attr_with_substring(&operands))
+                    }
+                }
+            }),
+        };
 
         exprs
             .attribute_exprs
-            .push(expr_result.unwrap_or_else(|_| self.compile_expr(|_, _| false)));
+            .push(expr_result.unwrap_or_else(|_| Self::compile_expr(neg, |_, _| false)));
     }
 }
 
@@ -209,7 +212,7 @@ impl Compiler {
         Predicate {
             on_tag_name_exprs,
             on_attr_exprs,
-        }: &Predicate,
+        }: Predicate,
         branch: ExecutionBranch,
         enable_nth_of_type: &mut bool,
     ) -> Instruction {
@@ -281,7 +284,7 @@ impl Compiler {
             };
 
             self.instructions[position] =
-                Some(self.compile_predicate(&node.predicate, branch, enable_nth_of_type));
+                Some(self.compile_predicate(node.predicate, branch, enable_nth_of_type));
         }
 
         addr_range

--- a/src/selectors_vm/compiler.rs
+++ b/src/selectors_vm/compiler.rs
@@ -8,7 +8,6 @@ use crate::base::{BytesCow, HasReplacementsError};
 use crate::html::LocalName;
 use encoding_rs::Encoding;
 use selectors::attr::{AttrSelectorOperator, ParsedCaseSensitivity};
-use std::iter;
 
 type BytesOwned = Box<[u8]>;
 
@@ -193,7 +192,7 @@ impl Compilable for Expr<OnAttributesExpr> {
 
 pub(crate) struct Compiler {
     encoding: &'static Encoding,
-    instructions: Box<[Option<Instruction>]>,
+    instructions: Box<[Instruction]>,
     free_space_start: usize,
 }
 
@@ -282,9 +281,13 @@ impl Compiler {
                 jumps: self.compile_descendants(node.children, enable_nth_of_type),
                 hereditary_jumps: self.compile_descendants(node.descendants, enable_nth_of_type),
             };
+            let compiled = self.compile_predicate(node.predicate, branch, enable_nth_of_type);
 
-            self.instructions[position] =
-                Some(self.compile_predicate(node.predicate, branch, enable_nth_of_type));
+            debug_assert!(self.instructions[position].local_name_exprs.is_empty());
+            debug_assert!(self.instructions[position].attribute_exprs.is_empty());
+            if let Some(inst) = self.instructions.get_mut(position) {
+                *inst = compiled;
+            }
         }
 
         addr_range
@@ -297,20 +300,20 @@ impl Compiler {
     #[inline(never)]
     pub fn compile(mut self, ast: Ast) -> Program {
         let mut enable_nth_of_type = false;
-        self.instructions = iter::repeat_with(|| None)
-            .take(ast.cumulative_node_count)
+        self.instructions = (0..ast.cumulative_node_count)
+            .map(|_| Instruction::noop())
             .collect();
 
         let entry_points = self.compile_nodes(ast.root, &mut enable_nth_of_type);
+        debug_assert!(
+            self.instructions
+                .iter()
+                .all(|i| !i.local_name_exprs.is_empty() || !i.attribute_exprs.is_empty())
+        );
 
         Program {
-            instructions: self
-                .instructions
-                .into_vec()
-                .into_iter()
-                .map(|o| o.unwrap())
-                .collect(),
             entry_points,
+            instructions: self.instructions,
             enable_nth_of_type,
         }
     }

--- a/src/selectors_vm/program.rs
+++ b/src/selectors_vm/program.rs
@@ -31,6 +31,18 @@ pub(crate) struct Instruction {
 }
 
 impl Instruction {
+    pub fn noop() -> Self {
+        Self {
+            associated_branch: ExecutionBranch {
+                matched_ids: DenseHashSet::Inline(0),
+                jumps: None,
+                hereditary_jumps: None,
+            },
+            local_name_exprs: Default::default(),
+            attribute_exprs: Default::default(),
+        }
+    }
+
     pub fn try_exec_without_attrs<'i>(
         &'i self,
         state: &SelectorState<'_>,


### PR DESCRIPTION
The compiler has been copying every single string from the `Ast`, but it doesn't have to.

The BytesCow API was unclear about borrowing vs copying, so I've fixed that. Since that was affecting an accidentally-public API, it depends on a cleanup: https://github.com/cloudflare/lol-html/pull/311