### PR TITLE
Simplified HashSet out of existence

### DIFF
--- a/src/rewriter/handlers_dispatcher.rs
+++ b/src/rewriter/handlers_dispatcher.rs
@@ -2,22 +2,30 @@ use super::ElementDescriptor;
 use super::settings::*;
 use crate::rewritable_units::{DocumentEnd, Element, StartTag, Token, TokenCaptureFlags};
 use crate::selectors_vm::MatchInfo;
+use std::num::NonZero;
 
 #[derive(Copy, Clone, Default, Debug, PartialEq, Eq, Hash)]
 pub(crate) struct SelectorHandlersLocator {
-    pub element_handler_idx: Option<usize>,
-    pub comment_handler_idx: Option<usize>,
-    pub text_handler_idx: Option<usize>,
+    pub element_handler_idx: Option<Locator>,
+    pub comment_handler_idx: Option<Locator>,
+    pub text_handler_idx: Option<Locator>,
+}
+
+/// It's index+1, allows efficient Option<Locator> (unfortunately Rust has no non-FFFF type)
+pub(crate) type Locator = NonZero<u32>;
+
+fn locator_to_idx(locator: Locator) -> usize {
+    (locator.get() - 1) as usize
 }
 
 struct HandlerVecItem<H> {
     handler: H,
-    user_count: usize,
+    user_count: u32,
 }
 
 struct HandlerVec<H> {
     items: Vec<HandlerVecItem<H>>,
-    user_count: usize,
+    user_count: u32,
 }
 
 impl<H> Default for HandlerVec<H> {
@@ -31,24 +39,23 @@ impl<H> Default for HandlerVec<H> {
 
 impl<H> HandlerVec<H> {
     #[inline]
-    pub fn push(&mut self, handler: H, always_active: bool) {
+    pub fn push(&mut self, handler: H, always_active: bool) -> Option<Locator> {
         let item = HandlerVecItem {
             handler,
-            user_count: usize::from(always_active),
+            user_count: u32::from(always_active),
         };
 
         self.user_count += item.user_count;
         self.items.push(item);
+
+        let locator = self.items.len().try_into().ok().and_then(NonZero::new);
+        debug_assert!(locator.is_some());
+        locator
     }
 
     #[inline]
-    pub fn len(&self) -> usize {
-        self.items.len()
-    }
-
-    #[inline]
-    pub fn inc_user_count(&mut self, idx: usize) {
-        let Some(item) = self.items.get_mut(idx) else {
+    pub fn inc_user_count(&mut self, idx: Locator) {
+        let Some(item) = self.items.get_mut(locator_to_idx(idx)) else {
             debug_assert!(false);
             return;
         };
@@ -57,8 +64,8 @@ impl<H> HandlerVec<H> {
     }
 
     #[inline]
-    pub fn dec_user_count(&mut self, idx: usize) {
-        let Some(item) = self.items.get_mut(idx) else {
+    pub fn dec_user_count(&mut self, idx: Locator) {
+        let Some(item) = self.items.get_mut(locator_to_idx(idx)) else {
             debug_assert!(false);
             return;
         };
@@ -175,18 +182,15 @@ impl<'h, H: HandlerTypes> ContentHandlersDispatcher<'h, H> {
         handlers: ElementContentHandlers<'h, H>,
     ) -> SelectorHandlersLocator {
         SelectorHandlersLocator {
-            element_handler_idx: handlers.element.map(|h| {
-                self.element_handlers.push(h, false);
-                self.element_handlers.len() - 1
-            }),
-            comment_handler_idx: handlers.comments.map(|h| {
-                self.comment_handlers.push(h, false);
-                self.comment_handlers.len() - 1
-            }),
-            text_handler_idx: handlers.text.map(|h| {
-                self.text_handlers.push(h, false);
-                self.text_handlers.len() - 1
-            }),
+            element_handler_idx: handlers
+                .element
+                .and_then(|h| self.element_handlers.push(h, false)),
+            comment_handler_idx: handlers
+                .comments
+                .and_then(|h| self.comment_handlers.push(h, false)),
+            text_handler_idx: handlers
+                .text
+                .and_then(|h| self.text_handlers.push(h, false)),
         }
     }
 
@@ -260,9 +264,7 @@ impl<'h, H: HandlerTypes> ContentHandlersDispatcher<'h, H> {
 
                 debug_assert!(element.can_have_content());
                 if let Some(handler) = element.into_end_tag_handler() {
-                    elem_desc.end_tag_handler_idx = Some(self.end_tag_handlers.len());
-
-                    self.end_tag_handlers.push(handler, false);
+                    elem_desc.end_tag_handler_idx = self.end_tag_handlers.push(handler, false);
                 }
             }
         }
@@ -317,4 +319,9 @@ impl<'h, H: HandlerTypes> ContentHandlersDispatcher<'h, H> {
 
         flags
     }
+}
+
+#[test]
+fn locator_size() {
+    assert!(size_of::<SelectorHandlersLocator>() <= 12);
 }

--- a/src/rewriter/handlers_dispatcher.rs
+++ b/src/rewriter/handlers_dispatcher.rs
@@ -230,7 +230,7 @@ impl<'h, H: HandlerTypes> ContentHandlersDispatcher<'h, H> {
 
     #[inline]
     pub fn stop_matching(&mut self, elem_desc: ElementDescriptor) {
-        for &match_id in elem_desc.matched_content_handlers.iter() {
+        for match_id in elem_desc.matched_content_handlers.iter() {
             let Some(locator) = self.locators.get(match_id as usize) else {
                 debug_assert!(false);
                 continue;

--- a/src/rewriter/handlers_dispatcher.rs
+++ b/src/rewriter/handlers_dispatcher.rs
@@ -1,7 +1,7 @@
 use super::ElementDescriptor;
 use super::settings::*;
 use crate::rewritable_units::{DocumentEnd, Element, StartTag, Token, TokenCaptureFlags};
-use crate::selectors_vm::MatchInfo;
+use crate::selectors_vm::{MatchId, MatchInfo};
 use std::num::NonZero;
 
 #[derive(Copy, Clone, Default, Debug, PartialEq, Eq, Hash)]
@@ -139,6 +139,8 @@ pub(crate) struct ContentHandlersDispatcher<'h, H: HandlerTypes> {
     end_handlers: HandlerVec<H::EndHandler<'h>>,
     next_element_can_have_content: bool,
     matched_elements_with_removed_content: usize,
+    /// Dense index by match_id
+    locators: Vec<SelectorHandlersLocator>,
 }
 
 impl<H: HandlerTypes> Default for ContentHandlersDispatcher<'_, H> {
@@ -152,6 +154,7 @@ impl<H: HandlerTypes> Default for ContentHandlersDispatcher<'_, H> {
             end_handlers: Default::default(),
             next_element_can_have_content: false,
             matched_elements_with_removed_content: 0,
+            locators: Vec::new(),
         }
     }
 }
@@ -180,8 +183,9 @@ impl<'h, H: HandlerTypes> ContentHandlersDispatcher<'h, H> {
     pub fn add_selector_associated_handlers(
         &mut self,
         handlers: ElementContentHandlers<'h, H>,
-    ) -> SelectorHandlersLocator {
-        SelectorHandlersLocator {
+    ) -> MatchId {
+        let match_id = self.locators.len() as MatchId;
+        self.locators.push(SelectorHandlersLocator {
             element_handler_idx: handlers
                 .element
                 .and_then(|h| self.element_handlers.push(h, false)),
@@ -191,7 +195,8 @@ impl<'h, H: HandlerTypes> ContentHandlersDispatcher<'h, H> {
             text_handler_idx: handlers
                 .text
                 .and_then(|h| self.text_handlers.push(h, false)),
-        }
+        });
+        match_id
     }
 
     #[inline]
@@ -200,8 +205,11 @@ impl<'h, H: HandlerTypes> ContentHandlersDispatcher<'h, H> {
     }
 
     #[inline]
-    pub fn start_matching(&mut self, match_info: &MatchInfo<SelectorHandlersLocator>) {
-        let locator = match_info.payload;
+    pub fn start_matching(&mut self, match_info: &MatchInfo) {
+        let Some(locator) = self.locators.get(match_info.match_id as usize) else {
+            debug_assert!(false);
+            return;
+        };
 
         if match_info.with_content {
             if let Some(idx) = locator.comment_handler_idx {
@@ -222,7 +230,12 @@ impl<'h, H: HandlerTypes> ContentHandlersDispatcher<'h, H> {
 
     #[inline]
     pub fn stop_matching(&mut self, elem_desc: ElementDescriptor) {
-        for locator in elem_desc.matched_content_handlers {
+        for &match_id in elem_desc.matched_content_handlers.iter() {
+            let Some(locator) = self.locators.get(match_id as usize) else {
+                debug_assert!(false);
+                continue;
+            };
+
             if let Some(idx) = locator.comment_handler_idx {
                 self.comment_handlers.dec_user_count(idx);
             }

--- a/src/rewriter/rewrite_controller.rs
+++ b/src/rewriter/rewrite_controller.rs
@@ -1,4 +1,4 @@
-use super::handlers_dispatcher::{ContentHandlersDispatcher, SelectorHandlersLocator};
+use super::handlers_dispatcher::{ContentHandlersDispatcher, Locator, SelectorHandlersLocator};
 use super::{HandlerTypes, RewritingError, Settings};
 use crate::base::SharedEncoding;
 use crate::html::{LocalName, Namespace};
@@ -12,7 +12,7 @@ use hashbrown::{DefaultHashBuilder, HashSet};
 
 pub(crate) struct ElementDescriptor {
     pub matched_content_handlers: HashSet<SelectorHandlersLocator>,
-    pub end_tag_handler_idx: Option<usize>,
+    pub end_tag_handler_idx: Option<Locator>,
     pub remove_content: bool,
 }
 

--- a/src/rewriter/rewrite_controller.rs
+++ b/src/rewriter/rewrite_controller.rs
@@ -6,27 +6,26 @@ use crate::memory::SharedMemoryLimiter;
 use crate::parser::ActionError;
 use crate::rewritable_units::{DocumentEnd, Token, TokenCaptureFlags};
 use crate::selectors_vm::{
-    Ast, AuxStartTagInfoRequest, ElementData, MatchId, SelectorMatchingVm, VmError,
+    Ast, AuxStartTagInfoRequest, DenseHashSet, ElementData, SelectorMatchingVm, VmError,
 };
 use crate::transform_stream::{DispatcherError, StartTagHandlingResult, TransformController};
-use hashbrown::{DefaultHashBuilder, HashSet};
 
 pub(crate) struct ElementDescriptor {
-    pub matched_content_handlers: HashSet<MatchId>,
+    pub matched_content_handlers: DenseHashSet,
     pub end_tag_handler_idx: Option<Locator>,
     pub remove_content: bool,
 }
 
 impl ElementData for ElementDescriptor {
     #[inline]
-    fn matched_ids_mut(&mut self) -> &mut HashSet<MatchId> {
+    fn matched_ids_mut(&mut self) -> &mut DenseHashSet {
         &mut self.matched_content_handlers
     }
 
     #[inline]
-    fn new(hasher: DefaultHashBuilder) -> Self {
+    fn new() -> Self {
         Self {
-            matched_content_handlers: HashSet::with_hasher(hasher),
+            matched_content_handlers: DenseHashSet::new(),
             end_tag_handler_idx: None,
             remove_content: false,
         }
@@ -63,11 +62,10 @@ impl<'h, H: HandlerTypes> HtmlRewriteController<'h, H> {
             .into_iter()
             .chain(settings.element_content_handlers);
 
-        let hasher = DefaultHashBuilder::default();
         for (selector, handlers) in element_content_handlers {
-            let locator = dispatcher.add_selector_associated_handlers(handlers);
+            let match_id = dispatcher.add_selector_associated_handlers(handlers);
 
-            selectors_ast.add_selector(&selector, locator, hasher.clone());
+            selectors_ast.add_selector(&selector, match_id);
         }
 
         for handlers in settings.document_content_handlers {

--- a/src/rewriter/rewrite_controller.rs
+++ b/src/rewriter/rewrite_controller.rs
@@ -1,26 +1,25 @@
-use super::handlers_dispatcher::{ContentHandlersDispatcher, Locator, SelectorHandlersLocator};
+use super::handlers_dispatcher::{ContentHandlersDispatcher, Locator};
 use super::{HandlerTypes, RewritingError, Settings};
 use crate::base::SharedEncoding;
 use crate::html::{LocalName, Namespace};
 use crate::memory::SharedMemoryLimiter;
 use crate::parser::ActionError;
 use crate::rewritable_units::{DocumentEnd, Token, TokenCaptureFlags};
-use crate::selectors_vm::Ast;
-use crate::selectors_vm::{AuxStartTagInfoRequest, ElementData, SelectorMatchingVm, VmError};
+use crate::selectors_vm::{
+    Ast, AuxStartTagInfoRequest, ElementData, MatchId, SelectorMatchingVm, VmError,
+};
 use crate::transform_stream::{DispatcherError, StartTagHandlingResult, TransformController};
 use hashbrown::{DefaultHashBuilder, HashSet};
 
 pub(crate) struct ElementDescriptor {
-    pub matched_content_handlers: HashSet<SelectorHandlersLocator>,
+    pub matched_content_handlers: HashSet<MatchId>,
     pub end_tag_handler_idx: Option<Locator>,
     pub remove_content: bool,
 }
 
 impl ElementData for ElementDescriptor {
-    type MatchPayload = SelectorHandlersLocator;
-
     #[inline]
-    fn matched_payload_mut(&mut self) -> &mut HashSet<SelectorHandlersLocator> {
+    fn matched_ids_mut(&mut self) -> &mut HashSet<MatchId> {
         &mut self.matched_content_handlers
     }
 
@@ -104,7 +103,7 @@ impl<'h, H: HandlerTypes> HtmlRewriteController<'h, H> {
 impl<H: HandlerTypes> HtmlRewriteController<'_, H> {
     #[inline]
     fn respond_to_aux_info_request(
-        aux_info_req: AuxStartTagInfoRequest<ElementDescriptor, SelectorHandlersLocator>,
+        aux_info_req: AuxStartTagInfoRequest<ElementDescriptor>,
     ) -> StartTagHandlingResult<Self> {
         Err(DispatcherError::InfoRequest(Box::new(
             move |this, aux_info| {

--- a/src/selectors_vm/ast.rs
+++ b/src/selectors_vm/ast.rs
@@ -1,9 +1,9 @@
+use super::MatchId;
 use super::parser::{Selector, SelectorImplDescriptor};
 use hashbrown::{DefaultHashBuilder, HashSet};
 use selectors::attr::{AttrSelectorOperator, ParsedCaseSensitivity};
 use selectors::parser::{Combinator, Component, NthType};
 use std::fmt::{self, Debug, Formatter};
-use std::hash::Hash;
 
 #[derive(PartialEq, Eq, Debug, Copy, Clone)]
 pub(crate) struct NthChild {
@@ -227,20 +227,14 @@ impl Predicate {
 }
 
 #[derive(PartialEq, Eq, Debug)]
-pub(crate) struct AstNode<P>
-where
-    P: Hash + Eq,
-{
+pub(crate) struct AstNode {
     pub predicate: Predicate,
     pub children: Vec<Self>,
     pub descendants: Vec<Self>,
-    pub payload: HashSet<P>,
+    pub match_ids: HashSet<MatchId>,
 }
 
-impl<P> AstNode<P>
-where
-    P: Hash + Eq,
-{
+impl AstNode {
     #[inline]
     #[must_use]
     fn new(predicate: Predicate, hasher: DefaultHashBuilder) -> Self {
@@ -248,30 +242,24 @@ where
             predicate,
             children: Vec::default(),
             descendants: Vec::default(),
-            payload: HashSet::with_hasher(hasher),
+            match_ids: HashSet::with_hasher(hasher),
         }
     }
 }
 
 // exposed for selectors_ast tool
 #[derive(Default, PartialEq, Eq, Debug)]
-pub struct Ast<P>
-where
-    P: PartialEq + Eq + Copy + Debug + Hash,
-{
-    pub(crate) root: Vec<AstNode<P>>,
+pub struct Ast {
+    pub(crate) root: Vec<AstNode>,
     // NOTE: used to preallocate instruction vector during compilation.
     pub(crate) cumulative_node_count: usize,
 }
 
-impl<P> Ast<P>
-where
-    P: PartialEq + Eq + Copy + Debug + Hash,
-{
+impl Ast {
     #[inline]
     fn host_expressions(
         predicate: Predicate,
-        branches: &mut Vec<AstNode<P>>,
+        branches: &mut Vec<AstNode>,
         cumulative_node_count: &mut usize,
         hasher: DefaultHashBuilder,
     ) -> usize {
@@ -288,7 +276,13 @@ where
             })
     }
 
-    pub fn add_selector(&mut self, selector: &Selector, payload: P, hasher: DefaultHashBuilder) {
+    /// `match_id` is a small integer chosen by the caller. It will be returned back in `MatchInfo`
+    pub fn add_selector(
+        &mut self,
+        selector: &Selector,
+        match_id: MatchId,
+        hasher: DefaultHashBuilder,
+    ) {
         for selector_item in (selector.0).slice() {
             let mut predicate = Predicate::default();
             let mut branches = &mut self.root;
@@ -331,7 +325,7 @@ where
                 hasher.clone(),
             );
 
-            branches[node_idx].payload.insert(payload);
+            branches[node_idx].match_ids.insert(match_id);
         }
     }
 }
@@ -348,11 +342,11 @@ mod tests {
     }
 
     #[track_caller]
-    fn assert_ast(selectors: &[&str], expected: Ast<usize>) {
+    fn assert_ast(selectors: &[&str], expected: Ast) {
         let mut ast = Ast::default();
 
-        for (idx, selector) in selectors.iter().enumerate() {
-            ast.add_selector(&selector.parse().unwrap(), idx, Default::default());
+        for (selector, match_id) in selectors.iter().zip(0..) {
+            ast.add_selector(&selector.parse().unwrap(), match_id, Default::default());
         }
 
         assert_eq!(ast, expected);
@@ -398,7 +392,7 @@ mod tests {
                         },
                         children: vec![],
                         descendants: vec![],
-                        payload: set![0],
+                        match_ids: set![0],
                     }],
                     cumulative_node_count: 1,
                 },
@@ -553,7 +547,7 @@ mod tests {
                         },
                         children: vec![],
                         descendants: vec![],
-                        payload: set![0],
+                        match_ids: set![0],
                     }],
                     cumulative_node_count: 1,
                 },
@@ -589,7 +583,7 @@ mod tests {
                     },
                     children: vec![],
                     descendants: vec![],
-                    payload: set![0],
+                    match_ids: set![0],
                 }],
                 cumulative_node_count: 1,
             },
@@ -611,7 +605,7 @@ mod tests {
                     },
                     children: vec![],
                     descendants: vec![],
-                    payload: set![0, 1],
+                    match_ids: set![0, 1],
                 }],
                 cumulative_node_count: 1,
             },
@@ -642,7 +636,7 @@ mod tests {
                             },
                             children: vec![],
                             descendants: vec![],
-                            payload: set![0],
+                            match_ids: set![0],
                         },
                         AstNode {
                             predicate: Predicate {
@@ -654,7 +648,7 @@ mod tests {
                             },
                             children: vec![],
                             descendants: vec![],
-                            payload: set![0],
+                            match_ids: set![0],
                         },
                         AstNode {
                             predicate: Predicate {
@@ -666,7 +660,7 @@ mod tests {
                             },
                             children: vec![],
                             descendants: vec![],
-                            payload: set![1],
+                            match_ids: set![1],
                         },
                         AstNode {
                             predicate: Predicate {
@@ -678,11 +672,11 @@ mod tests {
                             },
                             children: vec![],
                             descendants: vec![],
-                            payload: set![1],
+                            match_ids: set![1],
                         },
                     ],
                     descendants: vec![],
-                    payload: set![],
+                    match_ids: set![],
                 }],
                 cumulative_node_count: 5,
             },
@@ -740,9 +734,9 @@ mod tests {
                                             },
                                             children: vec![],
                                             descendants: vec![],
-                                            payload: set![0],
+                                            match_ids: set![0],
                                         }],
-                                        payload: set![],
+                                        match_ids: set![],
                                     },
                                     AstNode {
                                         predicate: Predicate {
@@ -754,10 +748,10 @@ mod tests {
                                         },
                                         children: vec![],
                                         descendants: vec![],
-                                        payload: set![1],
+                                        match_ids: set![1],
                                     },
                                 ],
-                                payload: set![],
+                                match_ids: set![],
                             },
                             AstNode {
                                 predicate: Predicate {
@@ -769,7 +763,7 @@ mod tests {
                                 },
                                 children: vec![],
                                 descendants: vec![],
-                                payload: set![2],
+                                match_ids: set![2],
                             },
                         ],
                         descendants: vec![
@@ -783,7 +777,7 @@ mod tests {
                                 },
                                 children: vec![],
                                 descendants: vec![],
-                                payload: set![3],
+                                match_ids: set![3],
                             },
                             AstNode {
                                 predicate: Predicate {
@@ -808,12 +802,12 @@ mod tests {
                                     },
                                     children: vec![],
                                     descendants: vec![],
-                                    payload: set![4],
+                                    match_ids: set![4],
                                 }],
-                                payload: set![],
+                                match_ids: set![],
                             },
                         ],
-                        payload: set![],
+                        match_ids: set![],
                     },
                     AstNode {
                         predicate: Predicate {
@@ -825,7 +819,7 @@ mod tests {
                         },
                         children: vec![],
                         descendants: vec![],
-                        payload: set![5],
+                        match_ids: set![5],
                     },
                 ],
                 cumulative_node_count: 10,
@@ -961,7 +955,7 @@ mod tests {
                     },
                     children: vec![],
                     descendants: vec![],
-                    payload: set![0],
+                    match_ids: set![0],
                 }],
                 cumulative_node_count: 1,
             },
@@ -980,7 +974,7 @@ mod tests {
                     },
                     children: vec![],
                     descendants: vec![],
-                    payload: set![0],
+                    match_ids: set![0],
                 }],
                 cumulative_node_count: 1,
             },
@@ -1002,7 +996,7 @@ mod tests {
                     },
                     children: vec![],
                     descendants: vec![],
-                    payload: set![0],
+                    match_ids: set![0],
                 }],
                 cumulative_node_count: 1,
             },

--- a/src/selectors_vm/ast.rs
+++ b/src/selectors_vm/ast.rs
@@ -1,6 +1,5 @@
-use super::MatchId;
 use super::parser::{Selector, SelectorImplDescriptor};
-use hashbrown::{DefaultHashBuilder, HashSet};
+use crate::selectors_vm::{DenseHashSet, MatchId};
 use selectors::attr::{AttrSelectorOperator, ParsedCaseSensitivity};
 use selectors::parser::{Combinator, Component, NthType};
 use std::fmt::{self, Debug, Formatter};
@@ -231,18 +230,18 @@ pub(crate) struct AstNode {
     pub predicate: Predicate,
     pub children: Vec<Self>,
     pub descendants: Vec<Self>,
-    pub match_ids: HashSet<MatchId>,
+    pub match_ids: DenseHashSet,
 }
 
 impl AstNode {
     #[inline]
     #[must_use]
-    fn new(predicate: Predicate, hasher: DefaultHashBuilder) -> Self {
+    fn new(predicate: Predicate) -> Self {
         Self {
             predicate,
             children: Vec::default(),
             descendants: Vec::default(),
-            match_ids: HashSet::with_hasher(hasher),
+            match_ids: DenseHashSet::new(),
         }
     }
 }
@@ -261,7 +260,6 @@ impl Ast {
         predicate: Predicate,
         branches: &mut Vec<AstNode>,
         cumulative_node_count: &mut usize,
-        hasher: DefaultHashBuilder,
     ) -> usize {
         branches
             .iter()
@@ -269,7 +267,7 @@ impl Ast {
             .find(|(_, n)| n.predicate == predicate)
             .map(|(i, _)| i)
             .unwrap_or_else(move || {
-                branches.push(AstNode::new(predicate, hasher));
+                branches.push(AstNode::new(predicate));
                 *cumulative_node_count += 1;
 
                 branches.len() - 1
@@ -277,12 +275,7 @@ impl Ast {
     }
 
     /// `match_id` is a small integer chosen by the caller. It will be returned back in `MatchInfo`
-    pub fn add_selector(
-        &mut self,
-        selector: &Selector,
-        match_id: MatchId,
-        hasher: DefaultHashBuilder,
-    ) {
+    pub fn add_selector(&mut self, selector: &Selector, match_id: MatchId) {
         for selector_item in (selector.0).slice() {
             let mut predicate = Predicate::default();
             let mut branches = &mut self.root;
@@ -293,7 +286,6 @@ impl Ast {
                         predicate,
                         branches,
                         &mut self.cumulative_node_count,
-                        hasher.clone(),
                     );
 
                     branches = &mut branches[node_idx].$branches;
@@ -318,12 +310,8 @@ impl Ast {
                 }
             }
 
-            let node_idx = Self::host_expressions(
-                predicate,
-                branches,
-                &mut self.cumulative_node_count,
-                hasher.clone(),
-            );
+            let node_idx =
+                Self::host_expressions(predicate, branches, &mut self.cumulative_node_count);
 
             branches[node_idx].match_ids.insert(match_id);
         }
@@ -333,20 +321,14 @@ impl Ast {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::selectors_vm::SelectorError;
-
-    macro_rules! set {
-        ($($items:expr),*) => {
-            vec![$($items),*].into_iter().collect::<HashSet<_>>()
-        };
-    }
+    use crate::selectors_vm::{DenseHashSet, SelectorError};
 
     #[track_caller]
     fn assert_ast(selectors: &[&str], expected: Ast) {
         let mut ast = Ast::default();
 
         for (selector, match_id) in selectors.iter().zip(0..) {
-            ast.add_selector(&selector.parse().unwrap(), match_id, Default::default());
+            ast.add_selector(&selector.parse().unwrap(), match_id);
         }
 
         assert_eq!(ast, expected);
@@ -392,7 +374,7 @@ mod tests {
                         },
                         children: vec![],
                         descendants: vec![],
-                        match_ids: set![0],
+                        match_ids: DenseHashSet::from([0]),
                     }],
                     cumulative_node_count: 1,
                 },
@@ -547,7 +529,7 @@ mod tests {
                         },
                         children: vec![],
                         descendants: vec![],
-                        match_ids: set![0],
+                        match_ids: DenseHashSet::from([0]),
                     }],
                     cumulative_node_count: 1,
                 },
@@ -583,7 +565,7 @@ mod tests {
                     },
                     children: vec![],
                     descendants: vec![],
-                    match_ids: set![0],
+                    match_ids: DenseHashSet::from([0]),
                 }],
                 cumulative_node_count: 1,
             },
@@ -605,7 +587,7 @@ mod tests {
                     },
                     children: vec![],
                     descendants: vec![],
-                    match_ids: set![0, 1],
+                    match_ids: DenseHashSet::from([0, 1]),
                 }],
                 cumulative_node_count: 1,
             },
@@ -636,7 +618,7 @@ mod tests {
                             },
                             children: vec![],
                             descendants: vec![],
-                            match_ids: set![0],
+                            match_ids: DenseHashSet::from([0]),
                         },
                         AstNode {
                             predicate: Predicate {
@@ -648,7 +630,7 @@ mod tests {
                             },
                             children: vec![],
                             descendants: vec![],
-                            match_ids: set![0],
+                            match_ids: DenseHashSet::from([0]),
                         },
                         AstNode {
                             predicate: Predicate {
@@ -660,7 +642,7 @@ mod tests {
                             },
                             children: vec![],
                             descendants: vec![],
-                            match_ids: set![1],
+                            match_ids: DenseHashSet::from([1]),
                         },
                         AstNode {
                             predicate: Predicate {
@@ -672,11 +654,11 @@ mod tests {
                             },
                             children: vec![],
                             descendants: vec![],
-                            match_ids: set![1],
+                            match_ids: DenseHashSet::from([1]),
                         },
                     ],
                     descendants: vec![],
-                    match_ids: set![],
+                    match_ids: DenseHashSet::from([]),
                 }],
                 cumulative_node_count: 5,
             },
@@ -734,9 +716,9 @@ mod tests {
                                             },
                                             children: vec![],
                                             descendants: vec![],
-                                            match_ids: set![0],
+                                            match_ids: DenseHashSet::from([0]),
                                         }],
-                                        match_ids: set![],
+                                        match_ids: DenseHashSet::from([]),
                                     },
                                     AstNode {
                                         predicate: Predicate {
@@ -748,10 +730,10 @@ mod tests {
                                         },
                                         children: vec![],
                                         descendants: vec![],
-                                        match_ids: set![1],
+                                        match_ids: DenseHashSet::from([1]),
                                     },
                                 ],
-                                match_ids: set![],
+                                match_ids: DenseHashSet::from([]),
                             },
                             AstNode {
                                 predicate: Predicate {
@@ -763,7 +745,7 @@ mod tests {
                                 },
                                 children: vec![],
                                 descendants: vec![],
-                                match_ids: set![2],
+                                match_ids: DenseHashSet::from([2]),
                             },
                         ],
                         descendants: vec![
@@ -777,7 +759,7 @@ mod tests {
                                 },
                                 children: vec![],
                                 descendants: vec![],
-                                match_ids: set![3],
+                                match_ids: DenseHashSet::from([3]),
                             },
                             AstNode {
                                 predicate: Predicate {
@@ -802,12 +784,12 @@ mod tests {
                                     },
                                     children: vec![],
                                     descendants: vec![],
-                                    match_ids: set![4],
+                                    match_ids: DenseHashSet::from([4]),
                                 }],
-                                match_ids: set![],
+                                match_ids: DenseHashSet::from([]),
                             },
                         ],
-                        match_ids: set![],
+                        match_ids: DenseHashSet::from([]),
                     },
                     AstNode {
                         predicate: Predicate {
@@ -819,7 +801,7 @@ mod tests {
                         },
                         children: vec![],
                         descendants: vec![],
-                        match_ids: set![5],
+                        match_ids: DenseHashSet::from([5]),
                     },
                 ],
                 cumulative_node_count: 10,
@@ -955,7 +937,7 @@ mod tests {
                     },
                     children: vec![],
                     descendants: vec![],
-                    match_ids: set![0],
+                    match_ids: DenseHashSet::from([0]),
                 }],
                 cumulative_node_count: 1,
             },
@@ -974,7 +956,7 @@ mod tests {
                     },
                     children: vec![],
                     descendants: vec![],
-                    match_ids: set![0],
+                    match_ids: DenseHashSet::from([0]),
                 }],
                 cumulative_node_count: 1,
             },
@@ -996,7 +978,7 @@ mod tests {
                     },
                     children: vec![],
                     descendants: vec![],
-                    match_ids: set![0],
+                    match_ids: DenseHashSet::from([0]),
                 }],
                 cumulative_node_count: 1,
             },

--- a/src/selectors_vm/compiler.rs
+++ b/src/selectors_vm/compiler.rs
@@ -318,16 +318,15 @@ mod tests {
     use super::*;
     use crate::html::Namespace;
     use crate::rewritable_units::Token;
-    use crate::selectors_vm::MatchId;
+    use crate::selectors_vm::{DenseHashSet, MatchId};
     use crate::selectors_vm::{TryExecResult, tests::test_with_token};
     use crate::test_utils::ASCII_COMPATIBLE_ENCODINGS;
     use encoding_rs::UTF_8;
-    use hashbrown::{DefaultHashBuilder, HashSet};
 
     macro_rules! assert_instr_res {
         ($res:expr, $should_match:expr, $selector:expr, $input:expr, $encoding:expr) => {{
             let expected_ids = if *$should_match {
-                Some(vec![0].into_iter().collect::<HashSet<_>>())
+                Some(DenseHashSet::from([0]))
             } else {
                 None
             };
@@ -354,9 +353,8 @@ mod tests {
     ) -> Program {
         let mut ast = Ast::default();
 
-        let hasher = DefaultHashBuilder::default();
         for (selector, match_id) in selectors.iter().zip(0..) {
-            ast.add_selector(&selector.parse().unwrap(), match_id, hasher.clone());
+            ast.add_selector(&selector.parse().unwrap(), match_id);
         }
 
         let program = Compiler::new(encoding).compile(ast);
@@ -530,7 +528,7 @@ mod tests {
 
     macro_rules! exec_instr_range {
         ($range:expr, $program:expr, $state:expr, $local_name:expr, $attr_matcher:expr) => {{
-            let mut matched_ids = HashSet::default();
+            let mut matched_ids = DenseHashSet::new();
             let mut jumps = Vec::default();
             let mut hereditary_jumps = Vec::default();
 
@@ -543,9 +541,7 @@ mod tests {
                 );
 
                 if let Some(res) = res {
-                    for &p in res.matched_ids.iter() {
-                        matched_ids.insert(p);
-                    }
+                    matched_ids.union(&res.matched_ids);
 
                     if let Some(ref j) = res.jumps {
                         jumps.push(j.to_owned());
@@ -565,7 +561,7 @@ mod tests {
         ($actual:expr, $expected:expr, $selectors:expr, $input:expr) => {
             assert_eq!(
                 $actual,
-                $expected.iter().cloned().collect::<HashSet<_>>(),
+                DenseHashSet::from($expected.iter().cloned()),
                 "Instructions didn't produce expected payload\n\
                  selectors: {:#?}\n\
                  input: {:#?}\n\

--- a/src/selectors_vm/compiler.rs
+++ b/src/selectors_vm/compiler.rs
@@ -8,8 +8,6 @@ use crate::base::{BytesCow, HasReplacementsError};
 use crate::html::LocalName;
 use encoding_rs::Encoding;
 use selectors::attr::{AttrSelectorOperator, ParsedCaseSensitivity};
-use std::fmt::Debug;
-use std::hash::Hash;
 use std::iter;
 
 type BytesOwned = Box<[u8]>;
@@ -190,19 +188,13 @@ impl Compilable for Expr<OnAttributesExpr> {
     }
 }
 
-pub(crate) struct Compiler<P>
-where
-    P: PartialEq + Eq + Copy + Debug + Hash,
-{
+pub(crate) struct Compiler {
     encoding: &'static Encoding,
-    instructions: Box<[Option<Instruction<P>>]>,
+    instructions: Box<[Option<Instruction>]>,
     free_space_start: usize,
 }
 
-impl<P: 'static> Compiler<P>
-where
-    P: PartialEq + Eq + Copy + Debug + Hash,
-{
+impl Compiler {
     #[must_use]
     pub fn new(encoding: &'static Encoding) -> Self {
         Self {
@@ -218,9 +210,9 @@ where
             on_tag_name_exprs,
             on_attr_exprs,
         }: &Predicate,
-        branch: ExecutionBranch<P>,
+        branch: ExecutionBranch,
         enable_nth_of_type: &mut bool,
-    ) -> Instruction<P> {
+    ) -> Instruction {
         let mut exprs = ExprSet::default();
 
         for c in on_tag_name_exprs {
@@ -249,7 +241,7 @@ where
 
     /// Reserves space for a set of nodes, returning the range for the nodes to be placed
     #[inline]
-    fn reserve(&mut self, nodes: &[AstNode<P>]) -> AddressRange {
+    fn reserve(&mut self, nodes: &[AstNode]) -> AddressRange {
         let addr_range = self.free_space_start..self.free_space_start + nodes.len();
 
         self.free_space_start = addr_range.end;
@@ -262,7 +254,7 @@ where
     #[inline]
     fn compile_descendants(
         &mut self,
-        nodes: Vec<AstNode<P>>,
+        nodes: Vec<AstNode>,
         enable_nth_of_type: &mut bool,
     ) -> Option<AddressRange> {
         if nodes.is_empty() {
@@ -274,7 +266,7 @@ where
 
     fn compile_nodes(
         &mut self,
-        nodes: Vec<AstNode<P>>,
+        nodes: Vec<AstNode>,
         enable_nth_of_type: &mut bool,
     ) -> AddressRange {
         // NOTE: we need sibling nodes to be in a contiguous region, so
@@ -283,7 +275,7 @@ where
 
         for (node, position) in nodes.into_iter().zip(addr_range.clone()) {
             let branch = ExecutionBranch {
-                matched_payload: node.payload,
+                matched_ids: node.match_ids,
                 jumps: self.compile_descendants(node.children, enable_nth_of_type),
                 hereditary_jumps: self.compile_descendants(node.descendants, enable_nth_of_type),
             };
@@ -300,7 +292,7 @@ where
     // It's better to outline it, and let its callers be inlined.
     #[must_use]
     #[inline(never)]
-    pub fn compile(mut self, ast: Ast<P>) -> Program<P> {
+    pub fn compile(mut self, ast: Ast) -> Program {
         let mut enable_nth_of_type = false;
         self.instructions = iter::repeat_with(|| None)
             .take(ast.cumulative_node_count)
@@ -326,6 +318,7 @@ mod tests {
     use super::*;
     use crate::html::Namespace;
     use crate::rewritable_units::Token;
+    use crate::selectors_vm::MatchId;
     use crate::selectors_vm::{TryExecResult, tests::test_with_token};
     use crate::test_utils::ASCII_COMPATIBLE_ENCODINGS;
     use encoding_rs::UTF_8;
@@ -333,15 +326,15 @@ mod tests {
 
     macro_rules! assert_instr_res {
         ($res:expr, $should_match:expr, $selector:expr, $input:expr, $encoding:expr) => {{
-            let expected_payload = if *$should_match {
+            let expected_ids = if *$should_match {
                 Some(vec![0].into_iter().collect::<HashSet<_>>())
             } else {
                 None
             };
 
             assert_eq!(
-                $res.map(|b| b.matched_payload.to_owned()),
-                expected_payload,
+                $res.map(|b| b.matched_ids.to_owned()),
+                expected_ids,
                 "Instruction didn't produce expected matching result\n\
                  selector: {:#?}\n\
                  input: {:#?}\n\
@@ -358,12 +351,12 @@ mod tests {
         selectors: &[&str],
         encoding: &'static Encoding,
         expected_entry_point_count: usize,
-    ) -> Program<usize> {
+    ) -> Program {
         let mut ast = Ast::default();
 
         let hasher = DefaultHashBuilder::default();
-        for (idx, selector) in selectors.iter().enumerate() {
-            ast.add_selector(&selector.parse().unwrap(), idx, hasher.clone());
+        for (selector, match_id) in selectors.iter().zip(0..) {
+            ast.add_selector(&selector.parse().unwrap(), match_id, hasher.clone());
         }
 
         let program = Compiler::new(encoding).compile(ast);
@@ -537,7 +530,7 @@ mod tests {
 
     macro_rules! exec_instr_range {
         ($range:expr, $program:expr, $state:expr, $local_name:expr, $attr_matcher:expr) => {{
-            let mut matched_payload = HashSet::default();
+            let mut matched_ids = HashSet::default();
             let mut jumps = Vec::default();
             let mut hereditary_jumps = Vec::default();
 
@@ -550,8 +543,8 @@ mod tests {
                 );
 
                 if let Some(res) = res {
-                    for &p in res.matched_payload.iter() {
-                        matched_payload.insert(p);
+                    for &p in res.matched_ids.iter() {
+                        matched_ids.insert(p);
                     }
 
                     if let Some(ref j) = res.jumps {
@@ -564,7 +557,7 @@ mod tests {
                 }
             }
 
-            (matched_payload, jumps, hereditary_jumps)
+            (matched_ids, jumps, hereditary_jumps)
         }};
     }
 
@@ -586,7 +579,7 @@ mod tests {
     fn assert_entry_points_match(
         selectors: &[&str],
         expected_entry_point_count: usize,
-        test_cases: &[(&str, Vec<usize>)],
+        test_cases: &[(&str, Vec<MatchId>)],
     ) {
         let program = test_compile(selectors, UTF_8, expected_entry_point_count);
 
@@ -595,8 +588,8 @@ mod tests {
         for_each_test_case(
             test_cases,
             UTF_8,
-            |input, expected_payload, state, local_name, attr_matcher| {
-                let (matched_payload, _, _) = exec_instr_range!(
+            |input, expected_ids, state, local_name, attr_matcher| {
+                let (matched_ids, _, _) = exec_instr_range!(
                     program.entry_points,
                     program,
                     state,
@@ -604,7 +597,7 @@ mod tests {
                     attr_matcher
                 );
 
-                assert_payload!(matched_payload, expected_payload, selectors, input);
+                assert_payload!(matched_ids, expected_ids, selectors, input);
             },
         );
     }
@@ -977,7 +970,7 @@ mod tests {
         let program = test_compile(&selectors, UTF_8, 2);
 
         macro_rules! exec {
-            ($html:expr, $add_range:expr, $expected_payload:expr) => {{
+            ($html:expr, $add_range:expr, $expected_ids:expr) => {{
                 let mut jumps = Vec::default();
                 let mut hereditary_jumps = Vec::default();
                 let counter = Default::default();
@@ -990,7 +983,7 @@ mod tests {
                     let res =
                         exec_instr_range!($add_range, program, &state, local_name, attr_matcher);
 
-                    assert_payload!(res.0, $expected_payload, selectors, $html);
+                    assert_payload!(res.0, $expected_ids, selectors, $html);
 
                     jumps = res.1;
                     hereditary_jumps = res.2;

--- a/src/selectors_vm/match_info.rs
+++ b/src/selectors_vm/match_info.rs
@@ -1,0 +1,102 @@
+use std::num::NonZeroU32;
+
+pub(crate) type MatchId = u32;
+
+pub(crate) struct MatchInfo {
+    pub match_id: MatchId,
+    pub with_content: bool,
+}
+
+#[derive(Eq, Debug, Clone, PartialEq)]
+pub(crate) enum DenseHashSet {
+    Inline(u32),
+    Heap(Box<[u32]>),
+}
+
+impl DenseHashSet {
+    pub fn new() -> Self {
+        Self::Inline(0)
+    }
+
+    pub fn insert(&mut self, value: MatchId) {
+        let int_idx = (value / 32) as usize;
+        let bit_idx = (value & 31) as u8;
+        let b = if let Some(b) = self.slice_mut().get_mut(int_idx) {
+            b
+        } else if let Some(b) = self.resize(int_idx * 2).get_mut(int_idx) {
+            b
+        } else {
+            debug_assert!(false);
+            return;
+        };
+        *b |= 1 << bit_idx;
+    }
+
+    pub fn union(&mut self, other: &Self) {
+        let mut bits = self.slice_mut();
+        let other = other.slice();
+        if bits.len() < other.len() {
+            bits = self.resize(other.len());
+        }
+        for (a, b) in bits.iter_mut().zip(other) {
+            *a |= *b;
+        }
+    }
+
+    pub fn iter(&self) -> impl Iterator<Item = MatchId> {
+        self.slice()
+            .iter()
+            .copied()
+            .enumerate()
+            .skip_while(|&(_, b)| b == 0)
+            .flat_map(|(int_idx, mut current_byte)| {
+                let base_bit_idx = 32 * int_idx as MatchId;
+                std::iter::from_fn(move || {
+                    let byte = NonZeroU32::new(current_byte)?;
+                    let match_id = base_bit_idx + byte.trailing_zeros();
+                    current_byte &= byte.get() - 1;
+
+                    Some(match_id)
+                })
+            })
+    }
+
+    fn slice_mut(&mut self) -> &mut [u32] {
+        match self {
+            Self::Heap(v) => v,
+            Self::Inline(v) => std::slice::from_mut(v),
+        }
+    }
+
+    fn slice(&self) -> &[u32] {
+        match self {
+            Self::Heap(v) => v,
+            Self::Inline(v) => std::slice::from_ref(v),
+        }
+    }
+
+    #[cold]
+    fn resize(&mut self, new_len: usize) -> &mut [u32] {
+        let bits = self.slice_mut();
+        let mut new = Vec::with_capacity(new_len);
+        new.copy_from_slice(bits);
+        let cap = new.capacity();
+        new.resize(cap, 0);
+        *self = Self::Heap(new.into_boxed_slice());
+        self.slice_mut()
+    }
+
+    #[cfg(test)]
+    pub fn from(values: impl IntoIterator<Item = MatchId>) -> Self {
+        let mut new = Self::new();
+        for v in values {
+            new.insert(v);
+        }
+        new
+    }
+}
+
+#[test]
+fn size() {
+    assert_eq!(16, size_of::<DenseHashSet>());
+}

--- a/src/selectors_vm/mod.rs
+++ b/src/selectors_vm/mod.rs
@@ -16,6 +16,8 @@ use crate::transform_stream::AuxStartTagInfo;
 use encoding_rs::Encoding;
 use hashbrown::DefaultHashBuilder;
 
+pub type MatchId = u32;
+
 pub use self::ast::*;
 pub(crate) use self::attribute_matcher::AttributeMatcher;
 pub(crate) use self::compiler::Compiler;
@@ -24,22 +26,22 @@ pub use self::parser::Selector;
 pub(crate) use self::program::{ExecutionBranch, Program, TryExecResult};
 pub(crate) use self::stack::{ChildCounter, ElementData, Stack, StackItem};
 
-pub(crate) struct MatchInfo<P> {
-    pub payload: P,
+pub(crate) struct MatchInfo {
+    pub match_id: MatchId,
     pub with_content: bool,
 }
 
-pub(crate) type AuxStartTagInfoRequest<E, P> = Box<
+pub(crate) type AuxStartTagInfoRequest<E> = Box<
     dyn FnOnce(
             &mut SelectorMatchingVm<E>,
             AuxStartTagInfo<'_>,
-            &mut dyn FnMut(MatchInfo<P>),
+            &mut dyn FnMut(MatchInfo),
         ) -> Result<(), MemoryLimitExceededError>
         + Send,
 >;
 
-pub(crate) enum VmError<E: ElementData, MatchPayload> {
-    InfoRequest(AuxStartTagInfoRequest<E, MatchPayload>),
+pub(crate) enum VmError<E: ElementData> {
+    InfoRequest(AuxStartTagInfoRequest<E>),
     MemoryLimitExceeded(MemoryLimitExceededError),
 }
 
@@ -93,11 +95,11 @@ impl<'i, E: ElementData> ExecutionCtx<'i, E> {
         }
     }
 
-    pub fn add_execution_branch(&mut self, branch: &ExecutionBranch<E::MatchPayload>) {
-        for &payload in &branch.matched_payload {
+    pub fn add_execution_branch(&mut self, branch: &ExecutionBranch) {
+        for &payload in &branch.matched_ids {
             self.stack_item
                 .element_data
-                .matched_payload_mut()
+                .matched_ids_mut()
                 .insert(payload);
         }
 
@@ -114,13 +116,11 @@ impl<'i, E: ElementData> ExecutionCtx<'i, E> {
         }
     }
 
-    pub fn flush_matched_payloads(
-        &mut self,
-        match_handler: &mut dyn FnMut(MatchInfo<E::MatchPayload>),
-    ) {
-        for &payload in self.stack_item.element_data.matched_payload_mut().iter() {
+    #[inline(never)]
+    pub fn handle_matched_ids(&mut self, match_handler: &mut dyn FnMut(MatchInfo)) {
+        for &match_id in self.stack_item.element_data.matched_ids_mut().iter() {
             match_handler(MatchInfo {
-                payload,
+                match_id,
                 with_content: self.with_content,
             });
         }
@@ -144,7 +144,7 @@ macro_rules! aux_info_request {
 }
 
 pub(crate) struct SelectorMatchingVm<E: ElementData> {
-    program: Program<E::MatchPayload>,
+    program: Program,
     stack: Stack<E>,
     enable_esi_tags: bool,
     hasher: DefaultHashBuilder,
@@ -157,7 +157,7 @@ where
     #[inline]
     #[must_use]
     pub fn new(
-        ast: Ast<E::MatchPayload>,
+        ast: Ast,
         encoding: &'static Encoding,
         memory_limiter: SharedMemoryLimiter,
         enable_esi_tags: bool,
@@ -178,8 +178,8 @@ where
         &mut self,
         local_name: LocalName<'_>,
         ns: Namespace,
-        match_handler: &mut dyn FnMut(MatchInfo<E::MatchPayload>),
-    ) -> Result<(), VmError<E, E::MatchPayload>> {
+        match_handler: &mut dyn FnMut(MatchInfo),
+    ) -> Result<(), VmError<E>> {
         use StackDirective::*;
 
         self.stack.add_child(&local_name);
@@ -220,7 +220,7 @@ where
         &mut self,
         mut ctx: ExecutionCtx<'static, E>,
         aux_info: AuxStartTagInfo<'_>,
-        match_handler: &mut dyn FnMut(MatchInfo<E::MatchPayload>),
+        match_handler: &mut dyn FnMut(MatchInfo),
     ) -> Result<(), MemoryLimitExceededError> {
         let attr_matcher = AttributeMatcher::new(*aux_info.input, aux_info.attr_buffer, ctx.ns);
 
@@ -236,7 +236,7 @@ where
             HereditaryJumpPtr::default(),
         );
 
-        ctx.flush_matched_payloads(match_handler);
+        ctx.handle_matched_ids(match_handler);
 
         if ctx.with_content {
             self.stack.push_item(ctx.stack_item)?;
@@ -249,7 +249,7 @@ where
         ctx: ExecutionCtx<'_, E>,
         bailout: Bailout<T>,
         recovery_point_handler: RecoveryPointHandler<T, E>,
-    ) -> Result<(), VmError<E, E::MatchPayload>> {
+    ) -> Result<(), VmError<E>> {
         let mut ctx = ctx.into_owned();
 
         aux_info_request!(move |this, aux_info, match_handler| {
@@ -259,7 +259,7 @@ where
 
             recovery_point_handler(this, &mut ctx, &attr_matcher, bailout.recovery_point);
 
-            ctx.flush_matched_payloads(match_handler);
+            ctx.handle_matched_ids(match_handler);
 
             if ctx.with_content {
                 this.stack.push_item(ctx.stack_item)?;
@@ -311,8 +311,8 @@ where
     fn exec_without_attrs(
         &mut self,
         mut ctx: ExecutionCtx<'_, E>,
-        match_handler: &mut dyn FnMut(MatchInfo<E::MatchPayload>),
-    ) -> Result<(), VmError<E, E::MatchPayload>> {
+        match_handler: &mut dyn FnMut(MatchInfo),
+    ) -> Result<(), VmError<E>> {
         if let Err(b) =
             self.try_exec_instr_set_without_attrs(self.program.entry_points.clone(), &mut ctx)
         {
@@ -327,7 +327,7 @@ where
             return Self::bailout(ctx, b, Self::recover_after_bailout_in_hereditary_jumps);
         }
 
-        ctx.flush_matched_payloads(match_handler);
+        ctx.handle_matched_ids(match_handler);
 
         if ctx.with_content {
             self.stack
@@ -527,20 +527,17 @@ mod tests {
         should_bailout: bool,
         should_match_with_content: bool,
         /// The indexes of selectors that match this tag
-        matched_payload: HashSet<usize>,
+        matched_ids: HashSet<MatchId>,
     }
 
-    #[derive(Default)]
-    struct TestElementData(HashSet<usize>);
+    struct TestElementData(HashSet<MatchId>);
 
     impl ElementData for TestElementData {
-        type MatchPayload = usize;
-
-        fn matched_payload_mut(&mut self) -> &mut HashSet<usize> {
+        fn matched_ids_mut(&mut self) -> &mut HashSet<MatchId> {
             &mut self.0
         }
-        fn new(_: DefaultHashBuilder) -> Self {
-            Self::default()
+        fn new(h: DefaultHashBuilder) -> Self {
+            Self(HashSet::with_hasher(h))
         }
     }
 
@@ -610,7 +607,7 @@ mod tests {
 
     macro_rules! set {
         ($($items:expr),*) => {
-            vec![$($items),*].into_iter().collect::<HashSet<_>>()
+            vec![$($items),*].into_iter().collect::<HashSet<MatchId>>()
         };
     }
 
@@ -632,8 +629,8 @@ mod tests {
             let mut ast = Ast::default();
 
             let hasher = DefaultHashBuilder::default();
-            for (i, selector) in $selectors.iter().enumerate() {
-                ast.add_selector(&selector.parse().unwrap(), i, hasher.clone());
+            for (selector, match_id) in $selectors.iter().zip(0..) {
+                ast.add_selector(&selector.parse().unwrap(), match_id, hasher.clone());
             }
 
             let memory_limiter = SharedMemoryLimiter::new(2048);
@@ -650,12 +647,12 @@ mod tests {
             test_with_token($tag_html, UTF_8, |t| {
                 match t {
                     Token::StartTag(t) => {
-                        let mut matched_payload = HashSet::default();
+                        let mut matched_ids = HashSet::default();
 
                         {
-                            let mut match_handler = |m: MatchInfo<_>| {
+                            let mut match_handler = |m: MatchInfo| {
                                 assert_eq!(m.with_content, $expectation.should_match_with_content);
-                                matched_payload.insert(m.payload);
+                                matched_ids.insert(m.match_id);
                             };
 
                             let result =
@@ -689,7 +686,7 @@ mod tests {
                             }
                         }
 
-                        assert_eq!(matched_payload, $expectation.matched_payload);
+                        assert_eq!(matched_ids, $expectation.matched_ids);
                     }
                     _ => panic!("Start tag expected"),
                 }
@@ -698,21 +695,21 @@ mod tests {
     }
 
     macro_rules! exec_for_end_tag_and_assert {
-        ($vm:expr, $tag_html:expr, $expected_unmatched_payload:expr) => {
+        ($vm:expr, $tag_html:expr, $expected_unmatched_ids:expr) => {
             test_with_token($tag_html, UTF_8, |t| match t {
                 Token::EndTag(t) => {
-                    let mut unmatched_payload = HashMap::default();
+                    let mut unmatched_ids = HashMap::default();
 
                     $vm.exec_for_end_tag(local_name!(t), |elem_data: TestElementData| {
-                        for payload in elem_data.0 {
-                            unmatched_payload
-                                .entry(payload)
+                        for &match_id in elem_data.0.iter() {
+                            unmatched_ids
+                                .entry(match_id)
                                 .and_modify(|c| *c += 1)
                                 .or_insert(1);
                         }
                     });
 
-                    assert_eq!(unmatched_payload, $expected_unmatched_payload);
+                    assert_eq!(unmatched_ids, $expected_unmatched_ids);
                 }
                 _ => panic!("End tag expected"),
             });
@@ -732,7 +729,7 @@ mod tests {
             Expectation {
                 should_bailout: false,
                 should_match_with_content: true,
-                matched_payload: set![0],
+                matched_ids: set![0],
             }
         );
 
@@ -746,7 +743,7 @@ mod tests {
             Expectation {
                 should_bailout: true,
                 should_match_with_content: false,
-                matched_payload: set![],
+                matched_ids: set![],
             }
         );
 
@@ -760,7 +757,7 @@ mod tests {
             Expectation {
                 should_bailout: true,
                 should_match_with_content: false,
-                matched_payload: set![1, 2],
+                matched_ids: set![1, 2],
             }
         );
 
@@ -774,7 +771,7 @@ mod tests {
             Expectation {
                 should_bailout: false,
                 should_match_with_content: true,
-                matched_payload: set![0],
+                matched_ids: set![0],
             }
         );
 
@@ -789,7 +786,7 @@ mod tests {
             Expectation {
                 should_bailout: true,
                 should_match_with_content: true,
-                matched_payload: set![2],
+                matched_ids: set![2],
             }
         );
 
@@ -805,7 +802,7 @@ mod tests {
             Expectation {
                 should_bailout: true,
                 should_match_with_content: true,
-                matched_payload: set![2],
+                matched_ids: set![2],
             }
         );
 
@@ -842,7 +839,7 @@ mod tests {
             Expectation {
                 should_bailout: true,
                 should_match_with_content: true,
-                matched_payload: set![],
+                matched_ids: set![],
             }
         );
 
@@ -856,7 +853,7 @@ mod tests {
             Expectation {
                 should_bailout: true,
                 should_match_with_content: false,
-                matched_payload: set![0, 1],
+                matched_ids: set![0, 1],
             }
         );
 
@@ -871,7 +868,7 @@ mod tests {
             Expectation {
                 should_bailout: true,
                 should_match_with_content: true,
-                matched_payload: set![0],
+                matched_ids: set![0],
             }
         );
 
@@ -890,7 +887,7 @@ mod tests {
             Expectation {
                 should_bailout: false,
                 should_match_with_content: true,
-                matched_payload: set![0],
+                matched_ids: set![0],
             }
         );
 
@@ -901,7 +898,7 @@ mod tests {
             Expectation {
                 should_bailout: true,
                 should_match_with_content: true,
-                matched_payload: set![],
+                matched_ids: set![],
             }
         );
 
@@ -912,7 +909,7 @@ mod tests {
             Expectation {
                 should_bailout: true,
                 should_match_with_content: true,
-                matched_payload: set![1],
+                matched_ids: set![1],
             }
         );
 
@@ -923,7 +920,7 @@ mod tests {
             Expectation {
                 should_bailout: true,
                 should_match_with_content: true,
-                matched_payload: set![1, 2],
+                matched_ids: set![1, 2],
             }
         );
 
@@ -941,7 +938,7 @@ mod tests {
             Expectation {
                 should_bailout: true,
                 should_match_with_content: true,
-                matched_payload: set![0, 1],
+                matched_ids: set![0, 1],
             }
         );
 
@@ -952,7 +949,7 @@ mod tests {
             Expectation {
                 should_bailout: true,
                 should_match_with_content: true,
-                matched_payload: set![0, 1, 2],
+                matched_ids: set![0, 1, 2],
             }
         );
     }
@@ -970,7 +967,7 @@ mod tests {
             Expectation {
                 should_bailout: false,
                 should_match_with_content: true,
-                matched_payload: set![],
+                matched_ids: set![],
             }
         );
 
@@ -984,7 +981,7 @@ mod tests {
             Expectation {
                 should_bailout: false,
                 should_match_with_content: true,
-                matched_payload: set![0, 1],
+                matched_ids: set![0, 1],
             }
         );
 
@@ -1002,7 +999,7 @@ mod tests {
             Expectation {
                 should_bailout: false,
                 should_match_with_content: false,
-                matched_payload: set![],
+                matched_ids: set![],
             }
         );
 
@@ -1020,7 +1017,7 @@ mod tests {
             Expectation {
                 should_bailout: false,
                 should_match_with_content: true,
-                matched_payload: set![1],
+                matched_ids: set![1],
             }
         );
 
@@ -1035,7 +1032,7 @@ mod tests {
             Expectation {
                 should_bailout: false,
                 should_match_with_content: true,
-                matched_payload: set![0, 1],
+                matched_ids: set![0, 1],
             }
         );
 
@@ -1065,7 +1062,7 @@ mod tests {
             Expectation {
                 should_bailout: false,
                 should_match_with_content: true,
-                matched_payload: set![],
+                matched_ids: set![],
             }
         );
 
@@ -1079,7 +1076,7 @@ mod tests {
             Expectation {
                 should_bailout: false,
                 should_match_with_content: true,
-                matched_payload: set![0, 1],
+                matched_ids: set![0, 1],
             }
         );
 
@@ -1097,7 +1094,7 @@ mod tests {
             Expectation {
                 should_bailout: false,
                 should_match_with_content: false,
-                matched_payload: set![],
+                matched_ids: set![],
             }
         );
 
@@ -1115,7 +1112,7 @@ mod tests {
             Expectation {
                 should_bailout: false,
                 should_match_with_content: true,
-                matched_payload: set![],
+                matched_ids: set![],
             }
         );
 
@@ -1130,7 +1127,7 @@ mod tests {
             Expectation {
                 should_bailout: false,
                 should_match_with_content: true,
-                matched_payload: set![0, 1],
+                matched_ids: set![0, 1],
             }
         );
 
@@ -1153,7 +1150,7 @@ mod tests {
             Expectation {
                 should_bailout: false,
                 should_match_with_content: true,
-                matched_payload: set![1],
+                matched_ids: set![1],
             }
         );
 
@@ -1168,7 +1165,7 @@ mod tests {
             Expectation {
                 should_bailout: false,
                 should_match_with_content: true,
-                matched_payload: set![0, 1],
+                matched_ids: set![0, 1],
             }
         );
 
@@ -1198,7 +1195,7 @@ mod tests {
             Expectation {
                 should_bailout: false,
                 should_match_with_content: true,
-                matched_payload: set![],
+                matched_ids: set![],
             }
         );
 
@@ -1212,7 +1209,7 @@ mod tests {
             Expectation {
                 should_bailout: true,
                 should_match_with_content: true,
-                matched_payload: set![0],
+                matched_ids: set![0],
             }
         );
 
@@ -1227,7 +1224,7 @@ mod tests {
             Expectation {
                 should_bailout: false,
                 should_match_with_content: true,
-                matched_payload: set![],
+                matched_ids: set![],
             }
         );
 
@@ -1250,7 +1247,7 @@ mod tests {
             Expectation {
                 should_bailout: true,
                 should_match_with_content: true,
-                matched_payload: set![1],
+                matched_ids: set![1],
             }
         );
 
@@ -1265,7 +1262,7 @@ mod tests {
             Expectation {
                 should_bailout: true,
                 should_match_with_content: true,
-                matched_payload: set![0, 2],
+                matched_ids: set![0, 2],
             }
         );
 
@@ -1286,7 +1283,7 @@ mod tests {
             Expectation {
                 should_bailout: true,
                 should_match_with_content: true,
-                matched_payload: set![],
+                matched_ids: set![],
             }
         );
 
@@ -1300,7 +1297,7 @@ mod tests {
             Expectation {
                 should_bailout: true,
                 should_match_with_content: true,
-                matched_payload: set![0, 1, 2],
+                matched_ids: set![0, 1, 2],
             }
         );
 
@@ -1318,7 +1315,7 @@ mod tests {
             Expectation {
                 should_bailout: true,
                 should_match_with_content: true,
-                matched_payload: set![1],
+                matched_ids: set![1],
             }
         );
 
@@ -1336,7 +1333,7 @@ mod tests {
             Expectation {
                 should_bailout: true,
                 should_match_with_content: true,
-                matched_payload: set![1, 3],
+                matched_ids: set![1, 3],
             }
         );
     }
@@ -1354,7 +1351,7 @@ mod tests {
             Expectation {
                 should_bailout: true,
                 should_match_with_content: true,
-                matched_payload: set![],
+                matched_ids: set![],
             }
         );
 
@@ -1368,7 +1365,7 @@ mod tests {
             Expectation {
                 should_bailout: true,
                 should_match_with_content: true,
-                matched_payload: set![0],
+                matched_ids: set![0],
             }
         );
 
@@ -1383,7 +1380,7 @@ mod tests {
             Expectation {
                 should_bailout: true,
                 should_match_with_content: true,
-                matched_payload: set![0, 1],
+                matched_ids: set![0, 1],
             }
         );
 
@@ -1399,7 +1396,7 @@ mod tests {
             Expectation {
                 should_bailout: true,
                 should_match_with_content: true,
-                matched_payload: set![1],
+                matched_ids: set![1],
             }
         );
 
@@ -1416,7 +1413,7 @@ mod tests {
             Expectation {
                 should_bailout: true,
                 should_match_with_content: true,
-                matched_payload: set![0, 1],
+                matched_ids: set![0, 1],
             }
         );
 
@@ -1435,7 +1432,7 @@ mod tests {
             Expectation {
                 should_bailout: true,
                 should_match_with_content: true,
-                matched_payload: set![0],
+                matched_ids: set![0],
             }
         );
     }
@@ -1458,7 +1455,7 @@ mod tests {
             Expectation {
                 should_bailout: false,
                 should_match_with_content: true,
-                matched_payload: set![],
+                matched_ids: set![],
             }
         );
 
@@ -1472,7 +1469,7 @@ mod tests {
             Expectation {
                 should_bailout: false,
                 should_match_with_content: true,
-                matched_payload: set![],
+                matched_ids: set![],
             }
         );
 
@@ -1486,7 +1483,7 @@ mod tests {
             Expectation {
                 should_bailout: true,
                 should_match_with_content: false,
-                matched_payload: set![0],
+                matched_ids: set![0],
             }
         );
 
@@ -1501,7 +1498,7 @@ mod tests {
             Expectation {
                 should_bailout: true,
                 should_match_with_content: true,
-                matched_payload: set![0, 1, 2, 3],
+                matched_ids: set![0, 1, 2, 3],
             }
         );
 
@@ -1517,7 +1514,7 @@ mod tests {
             Expectation {
                 should_bailout: true,
                 should_match_with_content: true,
-                matched_payload: set![0, 2],
+                matched_ids: set![0, 2],
             }
         );
 
@@ -1538,7 +1535,7 @@ mod tests {
             Expectation {
                 should_bailout: false,
                 should_match_with_content: true,
-                matched_payload: set![],
+                matched_ids: set![],
             }
         );
 
@@ -1552,7 +1549,7 @@ mod tests {
             Expectation {
                 should_bailout: false,
                 should_match_with_content: true,
-                matched_payload: set![0],
+                matched_ids: set![0],
             }
         );
 
@@ -1567,7 +1564,7 @@ mod tests {
             Expectation {
                 should_bailout: true,
                 should_match_with_content: true,
-                matched_payload: set![0, 1, 2],
+                matched_ids: set![0, 1, 2],
             }
         );
 
@@ -1583,7 +1580,7 @@ mod tests {
             Expectation {
                 should_bailout: true,
                 should_match_with_content: true,
-                matched_payload: set![0, 2],
+                matched_ids: set![0, 2],
             }
         );
 
@@ -1604,7 +1601,7 @@ mod tests {
             Expectation {
                 should_bailout: false,
                 should_match_with_content: true,
-                matched_payload: set![],
+                matched_ids: set![],
             }
         );
 
@@ -1618,7 +1615,7 @@ mod tests {
             Expectation {
                 should_bailout: true,
                 should_match_with_content: true,
-                matched_payload: set![],
+                matched_ids: set![],
             }
         );
 
@@ -1636,7 +1633,7 @@ mod tests {
             Expectation {
                 should_bailout: true,
                 should_match_with_content: true,
-                matched_payload: set![],
+                matched_ids: set![],
             }
         );
 
@@ -1651,7 +1648,7 @@ mod tests {
             Expectation {
                 should_bailout: true,
                 should_match_with_content: true,
-                matched_payload: set![],
+                matched_ids: set![],
             }
         );
 
@@ -1667,7 +1664,7 @@ mod tests {
             Expectation {
                 should_bailout: true,
                 should_match_with_content: true,
-                matched_payload: set![],
+                matched_ids: set![],
             }
         );
 
@@ -1684,7 +1681,7 @@ mod tests {
             Expectation {
                 should_bailout: true,
                 should_match_with_content: true,
-                matched_payload: set![],
+                matched_ids: set![],
             }
         );
 
@@ -1702,7 +1699,7 @@ mod tests {
             Expectation {
                 should_bailout: true,
                 should_match_with_content: true,
-                matched_payload: set![0],
+                matched_ids: set![0],
             }
         );
     }
@@ -1719,7 +1716,7 @@ mod tests {
             Expectation {
                 should_bailout: false,
                 should_match_with_content: true,
-                matched_payload: set![0],
+                matched_ids: set![0],
             }
         );
 
@@ -1735,7 +1732,7 @@ mod tests {
             Expectation {
                 should_bailout: false,
                 should_match_with_content: false,
-                matched_payload: set![],
+                matched_ids: set![],
             }
         );
     }
@@ -1763,8 +1760,8 @@ mod tests {
             };
             let mut calls = Vec::new();
 
-            let mut match_handler = |m: MatchInfo<_>| {
-                calls.push(m.payload);
+            let mut match_handler = |m: MatchInfo| {
+                calls.push(m.match_id);
             };
 
             let result = vm.exec_for_start_tag(local_name!(t), Namespace::Html, &mut match_handler);
@@ -1786,7 +1783,11 @@ mod tests {
             // // Sort for deterministic comparison (HashSet iteration order varies)
             // calls.sort();
 
-            assert_eq!(calls, [0, 1], "Each payload should be reported exactly once");
+            assert_eq!(
+                calls,
+                [0, 1],
+                "Each payload should be reported exactly once"
+            );
         });
     }
 }

--- a/src/selectors_vm/mod.rs
+++ b/src/selectors_vm/mod.rs
@@ -4,6 +4,7 @@ mod ast;
 mod attribute_matcher;
 mod compiler;
 mod error;
+mod match_info;
 mod parser;
 mod program;
 mod stack;
@@ -14,22 +15,15 @@ use crate::html::{LocalName, Namespace};
 use crate::memory::{MemoryLimitExceededError, SharedMemoryLimiter};
 use crate::transform_stream::AuxStartTagInfo;
 use encoding_rs::Encoding;
-use hashbrown::DefaultHashBuilder;
-
-pub type MatchId = u32;
 
 pub use self::ast::*;
 pub(crate) use self::attribute_matcher::AttributeMatcher;
 pub(crate) use self::compiler::Compiler;
 pub use self::error::SelectorError;
+pub(crate) use self::match_info::{DenseHashSet, MatchId, MatchInfo};
 pub use self::parser::Selector;
 pub(crate) use self::program::{ExecutionBranch, Program, TryExecResult};
 pub(crate) use self::stack::{ChildCounter, ElementData, Stack, StackItem};
-
-pub(crate) struct MatchInfo {
-    pub match_id: MatchId,
-    pub with_content: bool,
-}
 
 pub(crate) type AuxStartTagInfoRequest<E> = Box<
     dyn FnOnce(
@@ -81,27 +75,21 @@ struct ExecutionCtx<'i, E: ElementData> {
 
 impl<'i, E: ElementData> ExecutionCtx<'i, E> {
     #[inline]
-    pub fn new(
-        local_name: LocalName<'i>,
-        ns: Namespace,
-        enable_esi_tags: bool,
-        hasher: DefaultHashBuilder,
-    ) -> Self {
+    pub fn new(local_name: LocalName<'i>, ns: Namespace, enable_esi_tags: bool) -> Self {
         ExecutionCtx {
-            stack_item: StackItem::new(local_name, hasher),
+            stack_item: StackItem::new(local_name),
             with_content: true,
             ns,
             enable_esi_tags,
         }
     }
 
+    #[inline(never)]
     pub fn add_execution_branch(&mut self, branch: &ExecutionBranch) {
-        for &payload in &branch.matched_ids {
-            self.stack_item
-                .element_data
-                .matched_ids_mut()
-                .insert(payload);
-        }
+        self.stack_item
+            .element_data
+            .matched_ids_mut()
+            .union(&branch.matched_ids);
 
         if self.with_content {
             if let Some(ref jumps) = branch.jumps {
@@ -118,7 +106,7 @@ impl<'i, E: ElementData> ExecutionCtx<'i, E> {
 
     #[inline(never)]
     pub fn handle_matched_ids(&mut self, match_handler: &mut dyn FnMut(MatchInfo)) {
-        for &match_id in self.stack_item.element_data.matched_ids_mut().iter() {
+        for match_id in self.stack_item.element_data.matched_ids_mut().iter() {
             match_handler(MatchInfo {
                 match_id,
                 with_content: self.with_content,
@@ -147,7 +135,6 @@ pub(crate) struct SelectorMatchingVm<E: ElementData> {
     program: Program,
     stack: Stack<E>,
     enable_esi_tags: bool,
-    hasher: DefaultHashBuilder,
 }
 
 impl<E> SelectorMatchingVm<E>
@@ -163,14 +150,11 @@ where
         enable_esi_tags: bool,
     ) -> Self {
         let program = Compiler::new(encoding).compile(ast);
-        let enable_nth_of_type = program.enable_nth_of_type;
-        let hasher = DefaultHashBuilder::default();
 
         Self {
+            stack: Stack::new(memory_limiter, program.enable_nth_of_type),
             program,
-            stack: Stack::new(memory_limiter, enable_nth_of_type.then(|| hasher.clone())),
             enable_esi_tags,
-            hasher,
         }
     }
 
@@ -184,7 +168,7 @@ where
 
         self.stack.add_child(&local_name);
 
-        let mut ctx = ExecutionCtx::new(local_name, ns, self.enable_esi_tags, self.hasher.clone());
+        let mut ctx = ExecutionCtx::new(local_name, ns, self.enable_esi_tags);
 
         match Stack::get_stack_directive(&ctx.stack_item, ctx.ns, ctx.enable_esi_tags) {
             PopImmediately => {
@@ -521,23 +505,23 @@ mod tests {
         StartTagHandlingResult, TransformController, TransformStream, TransformStreamSettings,
     };
     use encoding_rs::{Encoding, UTF_8};
-    use hashbrown::{HashMap, HashSet};
+    use hashbrown::HashMap;
 
     struct Expectation {
         should_bailout: bool,
         should_match_with_content: bool,
         /// The indexes of selectors that match this tag
-        matched_ids: HashSet<MatchId>,
+        matched_ids: DenseHashSet,
     }
 
-    struct TestElementData(HashSet<MatchId>);
+    struct TestElementData(DenseHashSet);
 
     impl ElementData for TestElementData {
-        fn matched_ids_mut(&mut self) -> &mut HashSet<MatchId> {
+        fn matched_ids_mut(&mut self) -> &mut DenseHashSet {
             &mut self.0
         }
-        fn new(h: DefaultHashBuilder) -> Self {
-            Self(HashSet::with_hasher(h))
+        fn new() -> Self {
+            Self(DenseHashSet::new())
         }
     }
 
@@ -605,12 +589,6 @@ mod tests {
         transform_stream.end().unwrap();
     }
 
-    macro_rules! set {
-        ($($items:expr),*) => {
-            vec![$($items),*].into_iter().collect::<HashSet<MatchId>>()
-        };
-    }
-
     macro_rules! map {
         ($($items:expr),*) => {
             vec![$($items),*].into_iter().collect::<HashMap<_, _>>()
@@ -628,9 +606,8 @@ mod tests {
         ($selectors:expr) => {{
             let mut ast = Ast::default();
 
-            let hasher = DefaultHashBuilder::default();
             for (selector, match_id) in $selectors.iter().zip(0..) {
-                ast.add_selector(&selector.parse().unwrap(), match_id, hasher.clone());
+                ast.add_selector(&selector.parse().unwrap(), match_id);
             }
 
             let memory_limiter = SharedMemoryLimiter::new(2048);
@@ -647,7 +624,7 @@ mod tests {
             test_with_token($tag_html, UTF_8, |t| {
                 match t {
                     Token::StartTag(t) => {
-                        let mut matched_ids = HashSet::default();
+                        let mut matched_ids = DenseHashSet::new();
 
                         {
                             let mut match_handler = |m: MatchInfo| {
@@ -701,7 +678,7 @@ mod tests {
                     let mut unmatched_ids = HashMap::default();
 
                     $vm.exec_for_end_tag(local_name!(t), |elem_data: TestElementData| {
-                        for &match_id in elem_data.0.iter() {
+                        for match_id in elem_data.0.iter() {
                             unmatched_ids
                                 .entry(match_id)
                                 .and_modify(|c| *c += 1)
@@ -729,7 +706,7 @@ mod tests {
             Expectation {
                 should_bailout: false,
                 should_match_with_content: true,
-                matched_ids: set![0],
+                matched_ids: DenseHashSet::from([0]),
             }
         );
 
@@ -743,7 +720,7 @@ mod tests {
             Expectation {
                 should_bailout: true,
                 should_match_with_content: false,
-                matched_ids: set![],
+                matched_ids: DenseHashSet::from([]),
             }
         );
 
@@ -757,7 +734,7 @@ mod tests {
             Expectation {
                 should_bailout: true,
                 should_match_with_content: false,
-                matched_ids: set![1, 2],
+                matched_ids: DenseHashSet::from([1, 2]),
             }
         );
 
@@ -771,7 +748,7 @@ mod tests {
             Expectation {
                 should_bailout: false,
                 should_match_with_content: true,
-                matched_ids: set![0],
+                matched_ids: DenseHashSet::from([0]),
             }
         );
 
@@ -786,7 +763,7 @@ mod tests {
             Expectation {
                 should_bailout: true,
                 should_match_with_content: true,
-                matched_ids: set![2],
+                matched_ids: DenseHashSet::from([2]),
             }
         );
 
@@ -802,7 +779,7 @@ mod tests {
             Expectation {
                 should_bailout: true,
                 should_match_with_content: true,
-                matched_ids: set![2],
+                matched_ids: DenseHashSet::from([2]),
             }
         );
 
@@ -839,7 +816,7 @@ mod tests {
             Expectation {
                 should_bailout: true,
                 should_match_with_content: true,
-                matched_ids: set![],
+                matched_ids: DenseHashSet::from([]),
             }
         );
 
@@ -853,7 +830,7 @@ mod tests {
             Expectation {
                 should_bailout: true,
                 should_match_with_content: false,
-                matched_ids: set![0, 1],
+                matched_ids: DenseHashSet::from([0, 1]),
             }
         );
 
@@ -868,7 +845,7 @@ mod tests {
             Expectation {
                 should_bailout: true,
                 should_match_with_content: true,
-                matched_ids: set![0],
+                matched_ids: DenseHashSet::from([0]),
             }
         );
 
@@ -887,7 +864,7 @@ mod tests {
             Expectation {
                 should_bailout: false,
                 should_match_with_content: true,
-                matched_ids: set![0],
+                matched_ids: DenseHashSet::from([0]),
             }
         );
 
@@ -898,7 +875,7 @@ mod tests {
             Expectation {
                 should_bailout: true,
                 should_match_with_content: true,
-                matched_ids: set![],
+                matched_ids: DenseHashSet::from([]),
             }
         );
 
@@ -909,7 +886,7 @@ mod tests {
             Expectation {
                 should_bailout: true,
                 should_match_with_content: true,
-                matched_ids: set![1],
+                matched_ids: DenseHashSet::from([1]),
             }
         );
 
@@ -920,7 +897,7 @@ mod tests {
             Expectation {
                 should_bailout: true,
                 should_match_with_content: true,
-                matched_ids: set![1, 2],
+                matched_ids: DenseHashSet::from([1, 2]),
             }
         );
 
@@ -938,7 +915,7 @@ mod tests {
             Expectation {
                 should_bailout: true,
                 should_match_with_content: true,
-                matched_ids: set![0, 1],
+                matched_ids: DenseHashSet::from([0, 1]),
             }
         );
 
@@ -949,7 +926,7 @@ mod tests {
             Expectation {
                 should_bailout: true,
                 should_match_with_content: true,
-                matched_ids: set![0, 1, 2],
+                matched_ids: DenseHashSet::from([0, 1, 2]),
             }
         );
     }
@@ -967,7 +944,7 @@ mod tests {
             Expectation {
                 should_bailout: false,
                 should_match_with_content: true,
-                matched_ids: set![],
+                matched_ids: DenseHashSet::from([]),
             }
         );
 
@@ -981,7 +958,7 @@ mod tests {
             Expectation {
                 should_bailout: false,
                 should_match_with_content: true,
-                matched_ids: set![0, 1],
+                matched_ids: DenseHashSet::from([0, 1]),
             }
         );
 
@@ -999,7 +976,7 @@ mod tests {
             Expectation {
                 should_bailout: false,
                 should_match_with_content: false,
-                matched_ids: set![],
+                matched_ids: DenseHashSet::from([]),
             }
         );
 
@@ -1017,7 +994,7 @@ mod tests {
             Expectation {
                 should_bailout: false,
                 should_match_with_content: true,
-                matched_ids: set![1],
+                matched_ids: DenseHashSet::from([1]),
             }
         );
 
@@ -1032,7 +1009,7 @@ mod tests {
             Expectation {
                 should_bailout: false,
                 should_match_with_content: true,
-                matched_ids: set![0, 1],
+                matched_ids: DenseHashSet::from([0, 1]),
             }
         );
 
@@ -1062,7 +1039,7 @@ mod tests {
             Expectation {
                 should_bailout: false,
                 should_match_with_content: true,
-                matched_ids: set![],
+                matched_ids: DenseHashSet::from([]),
             }
         );
 
@@ -1076,7 +1053,7 @@ mod tests {
             Expectation {
                 should_bailout: false,
                 should_match_with_content: true,
-                matched_ids: set![0, 1],
+                matched_ids: DenseHashSet::from([0, 1]),
             }
         );
 
@@ -1094,7 +1071,7 @@ mod tests {
             Expectation {
                 should_bailout: false,
                 should_match_with_content: false,
-                matched_ids: set![],
+                matched_ids: DenseHashSet::from([]),
             }
         );
 
@@ -1112,7 +1089,7 @@ mod tests {
             Expectation {
                 should_bailout: false,
                 should_match_with_content: true,
-                matched_ids: set![],
+                matched_ids: DenseHashSet::from([]),
             }
         );
 
@@ -1127,7 +1104,7 @@ mod tests {
             Expectation {
                 should_bailout: false,
                 should_match_with_content: true,
-                matched_ids: set![0, 1],
+                matched_ids: DenseHashSet::from([0, 1]),
             }
         );
 
@@ -1150,7 +1127,7 @@ mod tests {
             Expectation {
                 should_bailout: false,
                 should_match_with_content: true,
-                matched_ids: set![1],
+                matched_ids: DenseHashSet::from([1]),
             }
         );
 
@@ -1165,7 +1142,7 @@ mod tests {
             Expectation {
                 should_bailout: false,
                 should_match_with_content: true,
-                matched_ids: set![0, 1],
+                matched_ids: DenseHashSet::from([0, 1]),
             }
         );
 
@@ -1195,7 +1172,7 @@ mod tests {
             Expectation {
                 should_bailout: false,
                 should_match_with_content: true,
-                matched_ids: set![],
+                matched_ids: DenseHashSet::from([]),
             }
         );
 
@@ -1209,7 +1186,7 @@ mod tests {
             Expectation {
                 should_bailout: true,
                 should_match_with_content: true,
-                matched_ids: set![0],
+                matched_ids: DenseHashSet::from([0]),
             }
         );
 
@@ -1224,7 +1201,7 @@ mod tests {
             Expectation {
                 should_bailout: false,
                 should_match_with_content: true,
-                matched_ids: set![],
+                matched_ids: DenseHashSet::from([]),
             }
         );
 
@@ -1247,7 +1224,7 @@ mod tests {
             Expectation {
                 should_bailout: true,
                 should_match_with_content: true,
-                matched_ids: set![1],
+                matched_ids: DenseHashSet::from([1]),
             }
         );
 
@@ -1262,7 +1239,7 @@ mod tests {
             Expectation {
                 should_bailout: true,
                 should_match_with_content: true,
-                matched_ids: set![0, 2],
+                matched_ids: DenseHashSet::from([0, 2]),
             }
         );
 
@@ -1283,7 +1260,7 @@ mod tests {
             Expectation {
                 should_bailout: true,
                 should_match_with_content: true,
-                matched_ids: set![],
+                matched_ids: DenseHashSet::from([]),
             }
         );
 
@@ -1297,7 +1274,7 @@ mod tests {
             Expectation {
                 should_bailout: true,
                 should_match_with_content: true,
-                matched_ids: set![0, 1, 2],
+                matched_ids: DenseHashSet::from([0, 1, 2]),
             }
         );
 
@@ -1315,7 +1292,7 @@ mod tests {
             Expectation {
                 should_bailout: true,
                 should_match_with_content: true,
-                matched_ids: set![1],
+                matched_ids: DenseHashSet::from([1]),
             }
         );
 
@@ -1333,7 +1310,7 @@ mod tests {
             Expectation {
                 should_bailout: true,
                 should_match_with_content: true,
-                matched_ids: set![1, 3],
+                matched_ids: DenseHashSet::from([1, 3]),
             }
         );
     }
@@ -1351,7 +1328,7 @@ mod tests {
             Expectation {
                 should_bailout: true,
                 should_match_with_content: true,
-                matched_ids: set![],
+                matched_ids: DenseHashSet::from([]),
             }
         );
 
@@ -1365,7 +1342,7 @@ mod tests {
             Expectation {
                 should_bailout: true,
                 should_match_with_content: true,
-                matched_ids: set![0],
+                matched_ids: DenseHashSet::from([0]),
             }
         );
 
@@ -1380,7 +1357,7 @@ mod tests {
             Expectation {
                 should_bailout: true,
                 should_match_with_content: true,
-                matched_ids: set![0, 1],
+                matched_ids: DenseHashSet::from([0, 1]),
             }
         );
 
@@ -1396,7 +1373,7 @@ mod tests {
             Expectation {
                 should_bailout: true,
                 should_match_with_content: true,
-                matched_ids: set![1],
+                matched_ids: DenseHashSet::from([1]),
             }
         );
 
@@ -1413,7 +1390,7 @@ mod tests {
             Expectation {
                 should_bailout: true,
                 should_match_with_content: true,
-                matched_ids: set![0, 1],
+                matched_ids: DenseHashSet::from([0, 1]),
             }
         );
 
@@ -1432,7 +1409,7 @@ mod tests {
             Expectation {
                 should_bailout: true,
                 should_match_with_content: true,
-                matched_ids: set![0],
+                matched_ids: DenseHashSet::from([0]),
             }
         );
     }
@@ -1455,7 +1432,7 @@ mod tests {
             Expectation {
                 should_bailout: false,
                 should_match_with_content: true,
-                matched_ids: set![],
+                matched_ids: DenseHashSet::from([]),
             }
         );
 
@@ -1469,7 +1446,7 @@ mod tests {
             Expectation {
                 should_bailout: false,
                 should_match_with_content: true,
-                matched_ids: set![],
+                matched_ids: DenseHashSet::from([]),
             }
         );
 
@@ -1483,7 +1460,7 @@ mod tests {
             Expectation {
                 should_bailout: true,
                 should_match_with_content: false,
-                matched_ids: set![0],
+                matched_ids: DenseHashSet::from([0]),
             }
         );
 
@@ -1498,7 +1475,7 @@ mod tests {
             Expectation {
                 should_bailout: true,
                 should_match_with_content: true,
-                matched_ids: set![0, 1, 2, 3],
+                matched_ids: DenseHashSet::from([0, 1, 2, 3]),
             }
         );
 
@@ -1514,7 +1491,7 @@ mod tests {
             Expectation {
                 should_bailout: true,
                 should_match_with_content: true,
-                matched_ids: set![0, 2],
+                matched_ids: DenseHashSet::from([0, 2]),
             }
         );
 
@@ -1535,7 +1512,7 @@ mod tests {
             Expectation {
                 should_bailout: false,
                 should_match_with_content: true,
-                matched_ids: set![],
+                matched_ids: DenseHashSet::from([]),
             }
         );
 
@@ -1549,7 +1526,7 @@ mod tests {
             Expectation {
                 should_bailout: false,
                 should_match_with_content: true,
-                matched_ids: set![0],
+                matched_ids: DenseHashSet::from([0]),
             }
         );
 
@@ -1564,7 +1541,7 @@ mod tests {
             Expectation {
                 should_bailout: true,
                 should_match_with_content: true,
-                matched_ids: set![0, 1, 2],
+                matched_ids: DenseHashSet::from([0, 1, 2]),
             }
         );
 
@@ -1580,7 +1557,7 @@ mod tests {
             Expectation {
                 should_bailout: true,
                 should_match_with_content: true,
-                matched_ids: set![0, 2],
+                matched_ids: DenseHashSet::from([0, 2]),
             }
         );
 
@@ -1601,7 +1578,7 @@ mod tests {
             Expectation {
                 should_bailout: false,
                 should_match_with_content: true,
-                matched_ids: set![],
+                matched_ids: DenseHashSet::from([]),
             }
         );
 
@@ -1615,7 +1592,7 @@ mod tests {
             Expectation {
                 should_bailout: true,
                 should_match_with_content: true,
-                matched_ids: set![],
+                matched_ids: DenseHashSet::from([]),
             }
         );
 
@@ -1633,7 +1610,7 @@ mod tests {
             Expectation {
                 should_bailout: true,
                 should_match_with_content: true,
-                matched_ids: set![],
+                matched_ids: DenseHashSet::from([]),
             }
         );
 
@@ -1648,7 +1625,7 @@ mod tests {
             Expectation {
                 should_bailout: true,
                 should_match_with_content: true,
-                matched_ids: set![],
+                matched_ids: DenseHashSet::from([]),
             }
         );
 
@@ -1664,7 +1641,7 @@ mod tests {
             Expectation {
                 should_bailout: true,
                 should_match_with_content: true,
-                matched_ids: set![],
+                matched_ids: DenseHashSet::from([]),
             }
         );
 
@@ -1681,7 +1658,7 @@ mod tests {
             Expectation {
                 should_bailout: true,
                 should_match_with_content: true,
-                matched_ids: set![],
+                matched_ids: DenseHashSet::from([]),
             }
         );
 
@@ -1699,7 +1676,7 @@ mod tests {
             Expectation {
                 should_bailout: true,
                 should_match_with_content: true,
-                matched_ids: set![0],
+                matched_ids: DenseHashSet::from([0]),
             }
         );
     }
@@ -1716,7 +1693,7 @@ mod tests {
             Expectation {
                 should_bailout: false,
                 should_match_with_content: true,
-                matched_ids: set![0],
+                matched_ids: DenseHashSet::from([0]),
             }
         );
 
@@ -1732,23 +1709,22 @@ mod tests {
             Expectation {
                 should_bailout: false,
                 should_match_with_content: false,
-                matched_ids: set![],
+                matched_ids: DenseHashSet::from([]),
             }
         );
     }
 
-    /// Test that match_handler is called exactly once per matched payload,
-    /// even when the same payload can be reached through multiple instruction paths.
-    /// For example, `"span, [foo$=bar]"` is one selector (payload 0) with two
-    /// comma-separated entries — both match `<span foo=bar>`, but payload 0
+    /// Test that match_handler is called exactly once per matched id,
+    /// even when the same match_ids can be reached through multiple instruction paths.
+    /// For example, `"span, [foo$=bar]"` is one selector (match_id 0) with two
+    /// comma-separated entries — both match `<span foo=bar>`, but match_id 0
     /// must be reported only once.
     #[test]
     fn no_duplicate_match_handler_calls() {
         let mut ast = Ast::default();
-        let hasher = DefaultHashBuilder::default();
-        ast.add_selector(&"span, [foo$=bar]".parse().unwrap(), 0, hasher.clone());
-        // Add a second selector "span" with payload 1 — should also match <span foo=bar>.
-        ast.add_selector(&"span".parse().unwrap(), 1, hasher);
+        ast.add_selector(&"span, [foo$=bar]".parse().unwrap(), 0);
+        // Add a second selector "span" with match_id 1 — should also match <span foo=bar>.
+        ast.add_selector(&"span".parse().unwrap(), 1);
 
         let memory_limiter = SharedMemoryLimiter::new(2048);
         let mut vm: SelectorMatchingVm<TestElementData> =
@@ -1778,7 +1754,7 @@ mod tests {
                     &mut match_handler,
                 )
                 .unwrap();
-            };
+            }
 
             // // Sort for deterministic comparison (HashSet iteration order varies)
             // calls.sort();
@@ -1786,7 +1762,7 @@ mod tests {
             assert_eq!(
                 calls,
                 [0, 1],
-                "Each payload should be reported exactly once"
+                "Each match_id should be reported exactly once"
             );
         });
     }

--- a/src/selectors_vm/mod.rs
+++ b/src/selectors_vm/mod.rs
@@ -43,13 +43,8 @@ pub(crate) enum VmError<E: ElementData, MatchPayload> {
     MemoryLimitExceeded(MemoryLimitExceededError),
 }
 
-type RecoveryPointHandler<T, E, P> = fn(
-    &mut SelectorMatchingVm<E>,
-    &mut ExecutionCtx<'static, E>,
-    &AttributeMatcher<'_>,
-    T,
-    &mut dyn FnMut(MatchInfo<P>),
-);
+type RecoveryPointHandler<T, E> =
+    fn(&mut SelectorMatchingVm<E>, &mut ExecutionCtx<'static, E>, &AttributeMatcher<'_>, T);
 
 #[derive(Default)]
 struct JumpPtr {
@@ -98,22 +93,12 @@ impl<'i, E: ElementData> ExecutionCtx<'i, E> {
         }
     }
 
-    pub fn add_execution_branch(
-        &mut self,
-        branch: &ExecutionBranch<E::MatchPayload>,
-        match_handler: &mut dyn FnMut(MatchInfo<E::MatchPayload>),
-    ) {
+    pub fn add_execution_branch(&mut self, branch: &ExecutionBranch<E::MatchPayload>) {
         for &payload in &branch.matched_payload {
-            let element_payload = self.stack_item.element_data.matched_payload_mut();
-
-            if !element_payload.contains(&payload) {
-                match_handler(MatchInfo {
-                    payload,
-                    with_content: self.with_content,
-                });
-
-                element_payload.insert(payload);
-            }
+            self.stack_item
+                .element_data
+                .matched_payload_mut()
+                .insert(payload);
         }
 
         if self.with_content {
@@ -126,6 +111,18 @@ impl<'i, E: ElementData> ExecutionCtx<'i, E> {
                     .hereditary_jumps
                     .push(hereditary_jumps.to_owned());
             }
+        }
+    }
+
+    pub fn flush_matched_payloads(
+        &mut self,
+        match_handler: &mut dyn FnMut(MatchInfo<E::MatchPayload>),
+    ) {
+        for &payload in self.stack_item.element_data.matched_payload_mut().iter() {
+            match_handler(MatchInfo {
+                payload,
+                with_content: self.with_content,
+            });
         }
     }
 
@@ -229,22 +226,17 @@ where
 
         ctx.with_content = !aux_info.self_closing;
 
-        self.exec_instr_set_with_attrs(
-            &self.program.entry_points,
-            &attr_matcher,
-            &mut ctx,
-            0,
-            match_handler,
-        );
+        self.exec_instr_set_with_attrs(&self.program.entry_points, &attr_matcher, &mut ctx, 0);
 
-        self.exec_jumps_with_attrs(&attr_matcher, &mut ctx, JumpPtr::default(), match_handler);
+        self.exec_jumps_with_attrs(&attr_matcher, &mut ctx, JumpPtr::default());
 
         self.exec_hereditary_jumps_with_attrs(
             &attr_matcher,
             &mut ctx,
             HereditaryJumpPtr::default(),
-            match_handler,
         );
+
+        ctx.flush_matched_payloads(match_handler);
 
         if ctx.with_content {
             self.stack.push_item(ctx.stack_item)?;
@@ -256,27 +248,18 @@ where
     fn bailout<T: 'static + Send>(
         ctx: ExecutionCtx<'_, E>,
         bailout: Bailout<T>,
-        recovery_point_handler: RecoveryPointHandler<T, E, E::MatchPayload>,
+        recovery_point_handler: RecoveryPointHandler<T, E>,
     ) -> Result<(), VmError<E, E::MatchPayload>> {
         let mut ctx = ctx.into_owned();
 
         aux_info_request!(move |this, aux_info, match_handler| {
             let attr_matcher = AttributeMatcher::new(*aux_info.input, aux_info.attr_buffer, ctx.ns);
 
-            this.complete_instr_execution_with_attrs(
-                bailout.at_addr,
-                &attr_matcher,
-                &mut ctx,
-                match_handler,
-            );
+            this.complete_instr_execution_with_attrs(bailout.at_addr, &attr_matcher, &mut ctx);
 
-            recovery_point_handler(
-                this,
-                &mut ctx,
-                &attr_matcher,
-                bailout.recovery_point,
-                match_handler,
-            );
+            recovery_point_handler(this, &mut ctx, &attr_matcher, bailout.recovery_point);
+
+            ctx.flush_matched_payloads(match_handler);
 
             if ctx.with_content {
                 this.stack.push_item(ctx.stack_item)?;
@@ -291,24 +274,17 @@ where
         ctx: &mut ExecutionCtx<'static, E>,
         attr_matcher: &AttributeMatcher<'_>,
         recovery_point: usize,
-        match_handler: &mut dyn FnMut(MatchInfo<E::MatchPayload>),
     ) {
         self.exec_instr_set_with_attrs(
             &self.program.entry_points,
             attr_matcher,
             ctx,
             recovery_point,
-            match_handler,
         );
 
-        self.exec_jumps_with_attrs(attr_matcher, ctx, JumpPtr::default(), match_handler);
+        self.exec_jumps_with_attrs(attr_matcher, ctx, JumpPtr::default());
 
-        self.exec_hereditary_jumps_with_attrs(
-            attr_matcher,
-            ctx,
-            HereditaryJumpPtr::default(),
-            match_handler,
-        );
+        self.exec_hereditary_jumps_with_attrs(attr_matcher, ctx, HereditaryJumpPtr::default());
     }
 
     fn recover_after_bailout_in_jumps(
@@ -316,16 +292,10 @@ where
         ctx: &mut ExecutionCtx<'static, E>,
         attr_matcher: &AttributeMatcher<'_>,
         recovery_point: JumpPtr,
-        match_handler: &mut dyn FnMut(MatchInfo<E::MatchPayload>),
     ) {
-        self.exec_jumps_with_attrs(attr_matcher, ctx, recovery_point, match_handler);
+        self.exec_jumps_with_attrs(attr_matcher, ctx, recovery_point);
 
-        self.exec_hereditary_jumps_with_attrs(
-            attr_matcher,
-            ctx,
-            HereditaryJumpPtr::default(),
-            match_handler,
-        );
+        self.exec_hereditary_jumps_with_attrs(attr_matcher, ctx, HereditaryJumpPtr::default());
     }
 
     #[inline]
@@ -334,9 +304,8 @@ where
         ctx: &mut ExecutionCtx<'static, E>,
         attr_matcher: &AttributeMatcher<'_>,
         recovery_point: HereditaryJumpPtr,
-        match_handler: &mut dyn FnMut(MatchInfo<E::MatchPayload>),
     ) {
-        self.exec_hereditary_jumps_with_attrs(attr_matcher, ctx, recovery_point, match_handler);
+        self.exec_hereditary_jumps_with_attrs(attr_matcher, ctx, recovery_point);
     }
 
     fn exec_without_attrs(
@@ -344,21 +313,21 @@ where
         mut ctx: ExecutionCtx<'_, E>,
         match_handler: &mut dyn FnMut(MatchInfo<E::MatchPayload>),
     ) -> Result<(), VmError<E, E::MatchPayload>> {
-        if let Err(b) = self.try_exec_instr_set_without_attrs(
-            self.program.entry_points.clone(),
-            &mut ctx,
-            match_handler,
-        ) {
+        if let Err(b) =
+            self.try_exec_instr_set_without_attrs(self.program.entry_points.clone(), &mut ctx)
+        {
             return Self::bailout(ctx, b, Self::recover_after_bailout_in_entry_points);
         }
 
-        if let Err(b) = self.try_exec_jumps_without_attrs(&mut ctx, match_handler) {
+        if let Err(b) = self.try_exec_jumps_without_attrs(&mut ctx) {
             return Self::bailout(ctx, b, Self::recover_after_bailout_in_jumps);
         }
 
-        if let Err(b) = self.try_exec_hereditary_jumps_without_attrs(&mut ctx, match_handler) {
+        if let Err(b) = self.try_exec_hereditary_jumps_without_attrs(&mut ctx) {
             return Self::bailout(ctx, b, Self::recover_after_bailout_in_hereditary_jumps);
         }
+
+        ctx.flush_matched_payloads(match_handler);
 
         if ctx.with_content {
             self.stack
@@ -375,13 +344,12 @@ where
         addr: usize,
         attr_matcher: &AttributeMatcher<'_>,
         ctx: &mut ExecutionCtx<'_, E>,
-        match_handler: &mut dyn FnMut(MatchInfo<E::MatchPayload>),
     ) {
         let state = self.stack.build_state(&ctx.stack_item.local_name);
         if let Some(branch) =
             self.program.instructions[addr].complete_exec_with_attrs(&state, attr_matcher)
         {
-            ctx.add_execution_branch(branch, match_handler);
+            ctx.add_execution_branch(branch);
         }
     }
 
@@ -390,7 +358,6 @@ where
         &self,
         addr_range: AddressRange,
         ctx: &mut ExecutionCtx<'_, E>,
-        match_handler: &mut dyn FnMut(MatchInfo<E::MatchPayload>),
     ) -> Result<(), Bailout<usize>> {
         let start = addr_range.start;
         let state = self.stack.build_state(&ctx.stack_item.local_name);
@@ -399,7 +366,7 @@ where
             match self.program.instructions[addr]
                 .try_exec_without_attrs(&state, &ctx.stack_item.local_name)
             {
-                TryExecResult::Branch(branch) => ctx.add_execution_branch(branch, match_handler),
+                TryExecResult::Branch(branch) => ctx.add_execution_branch(branch),
                 TryExecResult::AttributesRequired => {
                     return Err(Bailout {
                         at_addr: addr,
@@ -420,14 +387,13 @@ where
         attr_matcher: &AttributeMatcher<'_>,
         ctx: &mut ExecutionCtx<'_, E>,
         offset: usize,
-        match_handler: &mut dyn FnMut(MatchInfo<E::MatchPayload>),
     ) {
         let state = self.stack.build_state(&ctx.stack_item.local_name);
         for addr in addr_range.start + offset..addr_range.end {
             let instr = &self.program.instructions[addr];
 
             if let Some(branch) = instr.exec(&state, &ctx.stack_item.local_name, attr_matcher) {
-                ctx.add_execution_branch(branch, match_handler);
+                ctx.add_execution_branch(branch);
             }
         }
     }
@@ -435,11 +401,10 @@ where
     fn try_exec_jumps_without_attrs(
         &self,
         ctx: &mut ExecutionCtx<'_, E>,
-        match_handler: &mut dyn FnMut(MatchInfo<E::MatchPayload>),
     ) -> Result<(), Bailout<JumpPtr>> {
         if let Some(parent) = self.stack.items().last() {
             for (i, jumps) in parent.jumps.iter().enumerate() {
-                self.try_exec_instr_set_without_attrs(jumps.clone(), ctx, match_handler)
+                self.try_exec_instr_set_without_attrs(jumps.clone(), ctx)
                     .map_err(|b| Bailout {
                         at_addr: b.at_addr,
                         recovery_point: JumpPtr {
@@ -458,22 +423,15 @@ where
         attr_matcher: &AttributeMatcher<'_>,
         ctx: &mut ExecutionCtx<'_, E>,
         ptr: JumpPtr,
-        match_handler: &mut dyn FnMut(MatchInfo<E::MatchPayload>),
     ) {
         // NOTE: find pointed jumps instruction set and execute it with the offset.
         if let Some(parent) = self.stack.items().last() {
             if let Some(ptr_jumps) = parent.jumps.get(ptr.instr_set_idx) {
-                self.exec_instr_set_with_attrs(
-                    ptr_jumps,
-                    attr_matcher,
-                    ctx,
-                    ptr.offset,
-                    match_handler,
-                );
+                self.exec_instr_set_with_attrs(ptr_jumps, attr_matcher, ctx, ptr.offset);
 
                 // NOTE: execute remaining jumps instruction sets as usual.
                 for jumps in parent.jumps.iter().skip(ptr.instr_set_idx + 1) {
-                    self.exec_instr_set_with_attrs(jumps, attr_matcher, ctx, 0, match_handler);
+                    self.exec_instr_set_with_attrs(jumps, attr_matcher, ctx, 0);
                 }
             }
         }
@@ -482,11 +440,10 @@ where
     fn try_exec_hereditary_jumps_without_attrs(
         &self,
         ctx: &mut ExecutionCtx<'_, E>,
-        match_handler: &mut dyn FnMut(MatchInfo<E::MatchPayload>),
     ) -> Result<(), Bailout<HereditaryJumpPtr>> {
         for (i, ancestor) in self.stack.items().iter().rev().enumerate() {
             for (j, jumps) in ancestor.hereditary_jumps.iter().enumerate() {
-                self.try_exec_instr_set_without_attrs(jumps.clone(), ctx, match_handler)
+                self.try_exec_instr_set_without_attrs(jumps.clone(), ctx)
                     .map_err(move |b| Bailout {
                         at_addr: b.at_addr,
                         recovery_point: HereditaryJumpPtr {
@@ -510,7 +467,6 @@ where
         attr_matcher: &AttributeMatcher<'_>,
         ctx: &mut ExecutionCtx<'_, E>,
         ptr: HereditaryJumpPtr,
-        match_handler: &mut dyn FnMut(MatchInfo<E::MatchPayload>),
     ) {
         let items = self.stack.items();
 
@@ -524,13 +480,7 @@ where
         // set and execute it with the offset.
         if let Some(ptr_ancestor) = items.get(ptr_ancestor_idx) {
             if let Some(ptr_jumps) = ptr_ancestor.hereditary_jumps.get(ptr.instr_set_idx) {
-                self.exec_instr_set_with_attrs(
-                    ptr_jumps,
-                    attr_matcher,
-                    ctx,
-                    ptr.offset,
-                    match_handler,
-                );
+                self.exec_instr_set_with_attrs(ptr_jumps, attr_matcher, ctx, ptr.offset);
 
                 // NOTE: execute the rest of jump instruction sets in the pointed ancestor as usual.
                 for jumps in ptr_ancestor
@@ -538,7 +488,7 @@ where
                     .iter()
                     .skip(ptr.instr_set_idx + 1)
                 {
-                    self.exec_instr_set_with_attrs(jumps, attr_matcher, ctx, 0, match_handler);
+                    self.exec_instr_set_with_attrs(jumps, attr_matcher, ctx, 0);
                 }
             }
 
@@ -546,7 +496,7 @@ where
             if ptr_ancestor.has_ancestor_with_hereditary_jumps {
                 for ancestor in items.iter().rev().skip(ptr.stack_offset + 1) {
                     for jumps in &ancestor.hereditary_jumps {
-                        self.exec_instr_set_with_attrs(jumps, attr_matcher, ctx, 0, match_handler);
+                        self.exec_instr_set_with_attrs(jumps, attr_matcher, ctx, 0);
                     }
 
                     if !ancestor.has_ancestor_with_hereditary_jumps {
@@ -1836,12 +1786,7 @@ mod tests {
             // // Sort for deterministic comparison (HashSet iteration order varies)
             // calls.sort();
 
-            // Each payload must appear exactly once
-            assert_eq!(
-                calls,
-                vec![0, 1],
-                "Each payload should be reported exactly once, got: {calls:?}"
-            );
+            assert_eq!(calls, [0, 1], "Each payload should be reported exactly once");
         });
     }
 }

--- a/src/selectors_vm/mod.rs
+++ b/src/selectors_vm/mod.rs
@@ -1789,4 +1789,59 @@ mod tests {
             }
         );
     }
+
+    /// Test that match_handler is called exactly once per matched payload,
+    /// even when the same payload can be reached through multiple instruction paths.
+    /// For example, `"span, [foo$=bar]"` is one selector (payload 0) with two
+    /// comma-separated entries — both match `<span foo=bar>`, but payload 0
+    /// must be reported only once.
+    #[test]
+    fn no_duplicate_match_handler_calls() {
+        let mut ast = Ast::default();
+        let hasher = DefaultHashBuilder::default();
+        ast.add_selector(&"span, [foo$=bar]".parse().unwrap(), 0, hasher.clone());
+        // Add a second selector "span" with payload 1 — should also match <span foo=bar>.
+        ast.add_selector(&"span".parse().unwrap(), 1, hasher);
+
+        let memory_limiter = SharedMemoryLimiter::new(2048);
+        let mut vm: SelectorMatchingVm<TestElementData> =
+            SelectorMatchingVm::new(ast, UTF_8, memory_limiter, false);
+
+        test_with_token("<span foo=bar>", UTF_8, |t| {
+            let Token::StartTag(t) = t else {
+                panic!("must be start tag");
+            };
+            let mut calls = Vec::new();
+
+            let mut match_handler = |m: MatchInfo<_>| {
+                calls.push(m.payload);
+            };
+
+            let result = vm.exec_for_start_tag(local_name!(t), Namespace::Html, &mut match_handler);
+
+            if let Err(VmError::InfoRequest(inforeq)) = result {
+                let (input, attr_buffer) = t.raw_attributes();
+                inforeq(
+                    &mut vm,
+                    AuxStartTagInfo {
+                        input,
+                        attr_buffer,
+                        self_closing: t.self_closing(),
+                    },
+                    &mut match_handler,
+                )
+                .unwrap();
+            };
+
+            // // Sort for deterministic comparison (HashSet iteration order varies)
+            // calls.sort();
+
+            // Each payload must appear exactly once
+            assert_eq!(
+                calls,
+                vec![0, 1],
+                "Each payload should be reported exactly once, got: {calls:?}"
+            );
+        });
+    }
 }

--- a/src/selectors_vm/program.rs
+++ b/src/selectors_vm/program.rs
@@ -2,53 +2,41 @@ use super::SelectorState;
 use super::attribute_matcher::AttributeMatcher;
 use super::compiler::{CompiledAttributeExpr, CompiledLocalNameExpr};
 use crate::html::LocalName;
+use crate::selectors_vm::MatchId;
 use hashbrown::HashSet;
-use std::hash::Hash;
 use std::ops::Range;
 
 pub(crate) type AddressRange = Range<usize>;
 
 #[derive(Debug, PartialEq, Eq)]
-pub(crate) struct ExecutionBranch<P>
-where
-    P: Hash + Eq,
-{
-    pub matched_payload: HashSet<P>,
+pub(crate) struct ExecutionBranch {
+    pub matched_ids: HashSet<MatchId>,
     pub jumps: Option<AddressRange>,
     pub hereditary_jumps: Option<AddressRange>,
 }
 
 /// The result of trying to execute an instruction without having parsed all attributes
-pub(crate) enum TryExecResult<'i, P>
-where
-    P: Hash + Eq,
-{
+pub(crate) enum TryExecResult<'i> {
     /// A successful match, contains the branch to move to
-    Branch(&'i ExecutionBranch<P>),
+    Branch(&'i ExecutionBranch),
     /// A partially successful match, but requires attributes to complete
     AttributesRequired,
     /// A failed match, doesn't require attributes to complete
     Fail,
 }
 
-pub(crate) struct Instruction<P>
-where
-    P: Hash + Eq,
-{
-    pub associated_branch: ExecutionBranch<P>,
+pub(crate) struct Instruction {
+    pub associated_branch: ExecutionBranch,
     pub local_name_exprs: Box<[CompiledLocalNameExpr]>,
     pub attribute_exprs: Box<[CompiledAttributeExpr]>,
 }
 
-impl<P> Instruction<P>
-where
-    P: Hash + Eq,
-{
+impl Instruction {
     pub fn try_exec_without_attrs<'i>(
         &'i self,
         state: &SelectorState<'_>,
         local_name: &LocalName<'_>,
-    ) -> TryExecResult<'i, P> {
+    ) -> TryExecResult<'i> {
         if self.local_name_exprs.iter().all(|e| e(state, local_name)) {
             if self.attribute_exprs.is_empty() {
                 TryExecResult::Branch(&self.associated_branch)
@@ -64,7 +52,7 @@ where
         &'i self,
         state: &SelectorState<'_>,
         attr_matcher: &AttributeMatcher<'_>,
-    ) -> Option<&'i ExecutionBranch<P>> {
+    ) -> Option<&'i ExecutionBranch> {
         if self.attribute_exprs.iter().all(|e| e(state, attr_matcher)) {
             Some(&self.associated_branch)
         } else {
@@ -77,7 +65,7 @@ where
         state: &SelectorState<'_>,
         local_name: &LocalName<'_>,
         attr_matcher: &AttributeMatcher<'_>,
-    ) -> Option<&'i ExecutionBranch<P>> {
+    ) -> Option<&'i ExecutionBranch> {
         let is_match = self.local_name_exprs.iter().all(|e| e(state, local_name))
             && self.attribute_exprs.iter().all(|e| e(state, attr_matcher));
 
@@ -89,11 +77,8 @@ where
     }
 }
 
-pub(crate) struct Program<P>
-where
-    P: Hash + Eq,
-{
-    pub instructions: Box<[Instruction<P>]>,
+pub(crate) struct Program {
+    pub instructions: Box<[Instruction]>,
     pub entry_points: AddressRange,
     /// Enables tracking child types for nth-of-type selectors.
     /// This is disabled if no nth-of-type selectors are used in the program.

--- a/src/selectors_vm/program.rs
+++ b/src/selectors_vm/program.rs
@@ -2,15 +2,14 @@ use super::SelectorState;
 use super::attribute_matcher::AttributeMatcher;
 use super::compiler::{CompiledAttributeExpr, CompiledLocalNameExpr};
 use crate::html::LocalName;
-use crate::selectors_vm::MatchId;
-use hashbrown::HashSet;
+use crate::selectors_vm::DenseHashSet;
 use std::ops::Range;
 
 pub(crate) type AddressRange = Range<usize>;
 
 #[derive(Debug, PartialEq, Eq)]
 pub(crate) struct ExecutionBranch {
-    pub matched_ids: HashSet<MatchId>,
+    pub matched_ids: DenseHashSet,
     pub jumps: Option<AddressRange>,
     pub hereditary_jumps: Option<AddressRange>,
 }

--- a/src/selectors_vm/stack.rs
+++ b/src/selectors_vm/stack.rs
@@ -3,9 +3,10 @@ use super::ast::NthChild;
 use super::program::AddressRange;
 use crate::html::{LocalName, Namespace, Tag};
 use crate::memory::{LimitedVec, MemoryLimitExceededError, SharedMemoryLimiter};
-use crate::selectors_vm::MatchId;
+use crate::selectors_vm::DenseHashSet;
 // use hashbrown for raw entry, switch back to std once it stablizes there
-use hashbrown::{DefaultHashBuilder, HashMap, HashSet, hash_map::RawEntryMut};
+use hashbrown::HashMap;
+use hashbrown::hash_map::RawEntryMut;
 use std::hash::BuildHasher;
 
 #[inline]
@@ -38,8 +39,8 @@ fn is_void_element(local_name: &LocalName<'_>, enable_esi_tags: bool) -> bool {
 }
 
 pub(crate) trait ElementData: 'static {
-    fn matched_ids_mut(&mut self) -> &mut HashSet<MatchId>;
-    fn new(hasher: DefaultHashBuilder) -> Self;
+    fn matched_ids_mut(&mut self) -> &mut DenseHashSet;
+    fn new() -> Self;
 }
 
 pub(crate) enum StackDirective {
@@ -103,8 +104,8 @@ pub(crate) struct TypedChildCounterMap(HashMap<LocalName<'static>, CounterList>)
 impl TypedChildCounterMap {
     #[must_use]
     #[inline]
-    pub(crate) fn new(hasher: DefaultHashBuilder) -> Self {
-        Self(HashMap::with_hasher(hasher))
+    pub(crate) fn new() -> Self {
+        Self(HashMap::new())
     }
 
     fn hash_name(&self, name: &LocalName<'_>) -> u64 {
@@ -183,10 +184,10 @@ pub(crate) struct StackItem<'i, E: ElementData> {
 impl<'i, E: ElementData> StackItem<'i, E> {
     #[inline]
     #[must_use]
-    pub fn new(local_name: LocalName<'i>, hasher: DefaultHashBuilder) -> Self {
+    pub fn new(local_name: LocalName<'i>) -> Self {
         StackItem {
             local_name,
-            element_data: E::new(hasher),
+            element_data: E::new(),
             jumps: Vec::default(),
             hereditary_jumps: Vec::default(),
             child_counter: Default::default(),
@@ -220,13 +221,10 @@ pub(crate) struct Stack<E: ElementData> {
 impl<E: ElementData> Stack<E> {
     #[must_use]
     #[inline]
-    pub fn new(
-        memory_limiter: SharedMemoryLimiter,
-        enable_nth_of_type: Option<DefaultHashBuilder>,
-    ) -> Self {
+    pub fn new(memory_limiter: SharedMemoryLimiter, enable_nth_of_type: bool) -> Self {
         Self {
             root_child_counter: Default::default(),
-            typed_child_counters: enable_nth_of_type.map(TypedChildCounterMap::new),
+            typed_child_counters: enable_nth_of_type.then(TypedChildCounterMap::new),
             items: LimitedVec::new(memory_limiter),
         }
     }
@@ -331,17 +329,17 @@ impl<E: ElementData> Stack<E> {
 mod tests {
     use super::*;
     use crate::memory::SharedMemoryLimiter;
-    use crate::selectors_vm::MatchId;
+    use crate::selectors_vm::DenseHashSet;
     use encoding_rs::UTF_8;
 
     #[derive(Default)]
     struct TestElementData(usize);
 
     impl ElementData for TestElementData {
-        fn matched_ids_mut(&mut self) -> &mut HashSet<MatchId> {
+        fn matched_ids_mut(&mut self) -> &mut DenseHashSet {
             unreachable!();
         }
-        fn new(_: DefaultHashBuilder) -> Self {
+        fn new() -> Self {
             Self::default()
         }
     }
@@ -351,7 +349,7 @@ mod tests {
     }
 
     fn item(name: &'static str, data: usize) -> StackItem<'static, TestElementData> {
-        let mut item = StackItem::new(local_name(name), DefaultHashBuilder::default());
+        let mut item = StackItem::new(local_name(name));
 
         item.element_data = TestElementData(data);
 
@@ -361,7 +359,7 @@ mod tests {
     #[test]
     #[allow(clippy::reversed_empty_ranges)]
     fn hereditary_jumps_flag() {
-        let mut stack = Stack::new(SharedMemoryLimiter::new(2048), None);
+        let mut stack = Stack::new(SharedMemoryLimiter::new(2048), false);
 
         stack.push_item(item("item1", 0)).unwrap();
 
@@ -389,7 +387,7 @@ mod tests {
     fn pop_up_to() {
         macro_rules! assert_pop_result {
             ($up_to:expr, $expected_unmatched:expr, $expected_items:expr) => {{
-                let mut stack = Stack::new(SharedMemoryLimiter::new(2048), None);
+                let mut stack = Stack::new(SharedMemoryLimiter::new(2048), false);
 
                 stack.push_item(item("html", 0)).unwrap();
                 stack.push_item(item("body", 1)).unwrap();
@@ -431,7 +429,7 @@ mod tests {
 
     #[test]
     fn pop_up_to_on_empty_stack() {
-        let mut stack = Stack::new(SharedMemoryLimiter::new(2048), None);
+        let mut stack = Stack::new(SharedMemoryLimiter::new(2048), false);
         let mut handler_called = false;
 
         stack.pop_up_to(local_name("div"), |_: TestElementData| {

--- a/src/selectors_vm/stack.rs
+++ b/src/selectors_vm/stack.rs
@@ -3,10 +3,10 @@ use super::ast::NthChild;
 use super::program::AddressRange;
 use crate::html::{LocalName, Namespace, Tag};
 use crate::memory::{LimitedVec, MemoryLimitExceededError, SharedMemoryLimiter};
+use crate::selectors_vm::MatchId;
 // use hashbrown for raw entry, switch back to std once it stablizes there
 use hashbrown::{DefaultHashBuilder, HashMap, HashSet, hash_map::RawEntryMut};
-use std::fmt::Debug;
-use std::hash::{BuildHasher, Hash};
+use std::hash::BuildHasher;
 
 #[inline]
 fn is_void_element(local_name: &LocalName<'_>, enable_esi_tags: bool) -> bool {
@@ -38,9 +38,7 @@ fn is_void_element(local_name: &LocalName<'_>, enable_esi_tags: bool) -> bool {
 }
 
 pub(crate) trait ElementData: 'static {
-    type MatchPayload: PartialEq + Eq + Copy + Debug + Hash + 'static;
-
-    fn matched_payload_mut(&mut self) -> &mut HashSet<Self::MatchPayload>;
+    fn matched_ids_mut(&mut self) -> &mut HashSet<MatchId>;
     fn new(hasher: DefaultHashBuilder) -> Self;
 }
 
@@ -333,15 +331,14 @@ impl<E: ElementData> Stack<E> {
 mod tests {
     use super::*;
     use crate::memory::SharedMemoryLimiter;
+    use crate::selectors_vm::MatchId;
     use encoding_rs::UTF_8;
 
     #[derive(Default)]
     struct TestElementData(usize);
 
     impl ElementData for TestElementData {
-        type MatchPayload = ();
-
-        fn matched_payload_mut(&mut self) -> &mut HashSet<()> {
+        fn matched_ids_mut(&mut self) -> &mut HashSet<MatchId> {
             unreachable!();
         }
         fn new(_: DefaultHashBuilder) -> Self {

--- a/tools/selectors_ast/src/main.rs
+++ b/tools/selectors_ast/src/main.rs
@@ -11,8 +11,8 @@ fn main() {
     serde_json::from_str::<Vec<String>>(&arg)
         .expect("Expected JSON-list of selector strings")
         .iter()
-        .enumerate()
-        .for_each(|(i, s)| {
+        .zip(0..)
+        .for_each(|(s, i)| {
             let selector = s.parse().map_err(|e| format!("{e}")).unwrap();
 
             // private API

--- a/tools/selectors_ast/src/main.rs
+++ b/tools/selectors_ast/src/main.rs
@@ -16,7 +16,7 @@ fn main() {
             let selector = s.parse().map_err(|e| format!("{e}")).unwrap();
 
             // private API
-            ast.add_selector(&selector, i, Default::default());
+            ast.add_selector(&selector, i);
         });
 
     println!("{ast:#?}");


### PR DESCRIPTION
the selector vm has this pattern:
```
if !element_payload.contains(&payload) {
    match_handler(MatchInfo {
        payload,
        with_content: self.with_content,
    });

    element_payload.insert(payload);
}
```

which is effectively equivalent to calling the match handler once per item inserted to `element_payload`. So instead of going through `contains` + `insert` and dragging `match_handler` along everywhere where something may be inserted to `element_payload`, I've changed to insert everything first, and then call `match_handler` for every element afterwards. It is functionally equivalent, and much simpler than carrying `match_handler: &mut dyn FnMut(MatchInfo<E::MatchPayload>)` in the bailout/resume machinery.

`E::MatchPayload` was `SelectorHandlersLocator`, which was getting copied all over the selector matching vm, and infected everything with a generic type. I've made `SelectorHandlersLocator` 3x smaller, and realized it doesn't even have to exist in the selector vm, and can be replaced with selector's index. This made lots of VM types free from additional generic arguments.

I couldn't just replace `HashSet<SelectorHandlersLocator>` with `HashSet<usize>`, because that would iterate in non-deterministic order. I've made a basic bitset for it, which has a super fast union, and in common case (< 32 selectors) doesn't use heap allocations. It calls handlers in the same order as they were added to the rewriter, which is probably the most reasonable stable order (the previous was deterministic, but depended on implementation details of instruction execution). Many `DefaultHasherBuilder`s are gone too.



I've split it so that it is easier to review commit-by-commit