### PR TITLE
Remove deprecated set_name [this will fail CI semver check]

### DIFF
--- a/src/base/bytes.rs
+++ b/src/base/bytes.rs
@@ -7,8 +7,7 @@ use std::str;
 
 /// An error used to indicate that an encoded string has replacements and can't be converted losslessly.
 #[derive(Debug, Default, PartialEq, Eq, PartialOrd, Ord)]
-#[allow(unnameable_types)] // accidentally exposed via `tag.set_name()`
-pub struct HasReplacementsError;
+pub(crate) struct HasReplacementsError;
 
 /// A thin wrapper around byte slice with handy APIs attached
 #[derive(Copy, Clone, PartialEq, Eq, Hash, Default)]
@@ -17,7 +16,7 @@ pub(crate) struct Bytes<'b>(&'b [u8]);
 
 /// A thin wrapper around either byte slice or owned bytes with some handy APIs attached
 #[derive(Clone, PartialEq, Eq, Hash)]
-#[allow(unnameable_types)] // accidentally exposed via `tag.set_name()`
+#[allow(unnameable_types)] // it's pub only for integration test
 #[repr(transparent)]
 pub struct BytesCow<'b>(Cow<'b, [u8]>);
 
@@ -41,7 +40,7 @@ impl<'b> BytesCow<'b> {
     }
 
     #[inline]
-    pub fn from_str_without_replacements(
+    pub(crate) fn from_str_without_replacements(
         string: impl Into<Cow<'b, str>>,
         encoding: &'static Encoding,
     ) -> Result<Self, HasReplacementsError> {

--- a/src/rewritable_units/tokens/end_tag.rs
+++ b/src/rewritable_units/tokens/end_tag.rs
@@ -52,14 +52,6 @@ impl<'i> EndTag<'i> {
         self.name.as_string(self.encoding)
     }
 
-    #[doc(hidden)]
-    #[deprecated(
-        note = "this method won't convert the string encoding, and the type of the argument is a private implementation detail. Use set_name_str() instead"
-    )]
-    pub fn set_name(&mut self, name: BytesCow<'static>) {
-        self.set_name_raw(name);
-    }
-
     /// Sets the name of the tag.
     pub(crate) fn set_name_raw(&mut self, name: BytesCow<'static>) {
         self.name = name;
@@ -73,6 +65,18 @@ impl<'i> EndTag<'i> {
     /// The name must have a valid syntax, and the closing tag must be valid in its context.
     /// The parser will not take the new name into account, so if the new tag alters the structure of the document,
     /// the rest of the generated document will be parsed differently than during rewriting.
+    pub fn set_name(&mut self, name: impl Into<String>) {
+        self.set_name_str(name.into());
+    }
+
+    /// Sets the name of the tag only. To rename the element, prefer [`Element::set_tag_name()`][crate::html_content::Element::set_tag_name].
+    ///
+    /// The name will be converted to the document's encoding.
+    ///
+    /// The name must have a valid syntax, and the closing tag must be valid in its context.
+    /// The parser will not take the new name into account, so if the new tag alters the structure of the document,
+    /// the rest of the generated document will be parsed differently than during rewriting.
+    #[doc(hidden)]
     pub fn set_name_str(&mut self, name: String) {
         self.set_name_raw(BytesCow::from_string(name, self.encoding));
     }

--- a/src/rewritable_units/tokens/start_tag.rs
+++ b/src/rewritable_units/tokens/start_tag.rs
@@ -75,12 +75,8 @@ impl<'input_token> StartTag<'input_token> {
     /// The new tag name must be in the same namespace, have the same content model, and be valid in its location.
     /// Otherwise change of the tag name may cause the resulting document to be parsed in an unexpected way,
     /// out of sync with this library.
-    #[doc(hidden)]
-    #[deprecated(
-        note = "this method won't convert the string encoding, and the type of the argument is a private implementation detail. Use Element::set_tag_name() instead"
-    )]
-    pub fn set_name(&mut self, name: BytesCow<'static>) {
-        self.set_name_raw(name);
+    pub fn set_name(&mut self, name: impl Into<String>) {
+        self.set_name_raw(BytesCow::from_string(name.into(), self.encoding()));
     }
 
     /// Returns the [namespace URI] of the tag's element.


### PR DESCRIPTION
The set_name exposing a private type has been hidden and deprecated for a long time now. It was a niche method anyway, mostly unusable, so think it can be removed without a major semver bump.