### PR TITLE
Fix useless encoding in rewrite_str

### DIFF
--- a/src/rewritable_units/streaming_sink.rs
+++ b/src/rewritable_units/streaming_sink.rs
@@ -68,17 +68,13 @@ impl<'output_handler> StreamingHandlerSink<'output_handler> {
     #[inline]
     pub fn write_utf8_chunk(
         &mut self,
-        mut content: &[u8],
+        content: &[u8],
         content_type: ContentType,
     ) -> Result<(), Utf8Error> {
-        while !content.is_empty() {
-            let (valid_chunk, rest) = self.incomplete_utf8.utf8_bytes_to_slice(content)?;
-            content = rest;
-            if !valid_chunk.is_empty() {
+        self.incomplete_utf8
+            .write_utf8_chunk(content, |valid_chunk| {
                 self.inner.write_str(valid_chunk, content_type);
-            }
-        }
-        Ok(())
+            })
     }
 }
 

--- a/src/rewritable_units/text_encoder.rs
+++ b/src/rewritable_units/text_encoder.rs
@@ -208,6 +208,21 @@ impl IncompleteUtf8Resync {
             false
         }
     }
+
+    pub fn write_utf8_chunk(
+        &mut self,
+        mut content: &[u8],
+        mut flush: impl FnMut(&str),
+    ) -> Result<(), Utf8Error> {
+        while !content.is_empty() {
+            let (valid_chunk, rest) = self.utf8_bytes_to_slice(content)?;
+            content = rest;
+            if !valid_chunk.is_empty() {
+                flush(valid_chunk);
+            }
+        }
+        Ok(())
+    }
 }
 
 #[test]

--- a/src/rewriter/mod.rs
+++ b/src/rewriter/mod.rs
@@ -9,7 +9,7 @@ pub use self::settings::*;
 use crate::base::SharedEncoding;
 use crate::memory::{MemoryLimitExceededError, SharedMemoryLimiter};
 use crate::parser::ParsingAmbiguityError;
-use crate::rewritable_units::Element;
+use crate::rewritable_units::{Element, IncompleteUtf8Resync};
 use crate::transform_stream::*;
 use encoding_rs::Encoding;
 use mime::Mime;
@@ -300,17 +300,34 @@ pub fn rewrite_str<'h, 's, H: HandlerTypes>(
     html: &str,
     settings: impl Into<Settings<'h, 's, H>>,
 ) -> Result<String, RewritingError> {
-    let mut output = vec![];
+    let mut settings = settings.into();
+    settings.adjust_charset_on_meta_tag = false;
+    settings.encoding = AsciiCompatibleEncoding::utf_8();
 
-    let mut rewriter = HtmlRewriter::new(settings.into(), |c: &[u8]| {
-        output.extend_from_slice(c);
+    rewrite_str_utf8(html, settings)
+}
+
+#[inline(never)]
+fn rewrite_str_utf8<H: HandlerTypes>(
+    html: &str,
+    settings: Settings<'_, '_, H>,
+) -> Result<String, RewritingError> {
+    let mut out = String::new();
+    out.try_reserve(html.len())
+        .map_err(|_| RewritingError::MemoryLimitExceeded(MemoryLimitExceededError))?;
+
+    let mut resync = IncompleteUtf8Resync::new();
+    let mut rewriter = HtmlRewriter::new(settings, |chunk: &[u8]| {
+        if resync.write_utf8_chunk(chunk, |s| out.push_str(s)).is_err() {
+            // this shouldn't fail, because we've got UTF-8 input and blocked encoding changes
+            out.push('\u{FFFD}');
+        }
     });
 
     rewriter.write(html.as_bytes())?;
     rewriter.end()?;
 
-    // NOTE: it's ok to unwrap here as we guarantee encoding validity of the output
-    Ok(String::from_utf8(output).unwrap())
+    Ok(out)
 }
 
 #[cfg(test)]
@@ -441,6 +458,21 @@ mod tests {
     fn rewrite_arbitrary_settings() {
         let res = rewrite_str("<span>Some text</span>", Settings::new()).unwrap();
         assert_eq!(res, "<span>Some text</span>");
+    }
+
+    #[test]
+    fn rewrite_non_utf8() {
+        let text = "前<meta charset=latin1><span>中</span><!-- 後 -->";
+        let rewritten = rewrite_str(
+            text,
+            Settings {
+                encoding: encoding_rs::BIG5.try_into().unwrap(),
+                adjust_charset_on_meta_tag: true,
+                ..Settings::new()
+            },
+        )
+        .unwrap();
+        assert_eq!(rewritten, text);
     }
 
     #[test]


### PR DESCRIPTION
`rewrite_str` wasn't expecting `Settings` to allow non-UTF-8 encoding, and the final `String` conversion could fail.

It doesn't make sense to set any other encodings in `rewrite_str`, because the input is a UTF-8-only `&str`, so I've made it fix settings to keep UTF-8.

I've reused UTF-8 chunker we have for streaming handlers, so it can do UTF-8 validation incrementally.