### PR TITLE
Limit <svg><foreign-content> nesting depth

### DIFF
--- a/src/parser/lexer/actions.rs
+++ b/src/parser/lexer/actions.rs
@@ -91,7 +91,7 @@ impl<S: LexemeSink> StateMachineActions for Lexer<S> {
         self.set_last_text_type(TextType::Data);
 
         if let Some(feedback) = feedback {
-            self.handle_tree_builder_feedback(context, feedback, &lexeme);
+            self.handle_tree_builder_feedback(context, feedback, &lexeme)?;
         }
 
         if let StartTag {

--- a/src/parser/lexer/mod.rs
+++ b/src/parser/lexer/mod.rs
@@ -84,17 +84,21 @@ impl<S: LexemeSink> Lexer<S> {
         context: &mut ParserContext<S>,
         feedback: TreeBuilderFeedback,
         lexeme: &TagLexeme<'_>,
-    ) {
+    ) -> Result<(), ParsingAmbiguityError> {
         match feedback {
             TreeBuilderFeedback::SwitchTextType(text_type) => self.set_last_text_type(text_type),
             TreeBuilderFeedback::SetAllowCdata(cdata_allowed) => self.cdata_allowed = cdata_allowed,
             TreeBuilderFeedback::RequestLexeme(mut callback) => {
                 let feedback = callback(&mut context.tree_builder_simulator, lexeme);
 
-                self.handle_tree_builder_feedback(context, feedback, lexeme);
+                self.handle_tree_builder_feedback(context, feedback, lexeme)?;
+            }
+            TreeBuilderFeedback::DepthExceeded => {
+                return Err(ParsingAmbiguityError::depth_exceeded());
             }
             TreeBuilderFeedback::None => (),
         }
+        Ok(())
     }
 
     #[inline]

--- a/src/parser/tag_scanner/mod.rs
+++ b/src/parser/tag_scanner/mod.rs
@@ -124,6 +124,9 @@ impl<S: TagHintSink> TagScanner<S> {
             }
             TreeBuilderFeedback::RequestLexeme(_) => Some(feedback),
             TreeBuilderFeedback::None => None,
+            TreeBuilderFeedback::DepthExceeded => {
+                return Err(ParsingAmbiguityError::depth_exceeded());
+            }
         })
     }
 

--- a/src/parser/tree_builder_simulator/ambiguity_guard.rs
+++ b/src/parser/tree_builder_simulator/ambiguity_guard.rs
@@ -66,27 +66,64 @@ use thiserror::Error;
 /// correct parsing context.
 ///
 /// [`strict`]: ../struct.Settings.html#structfield.strict
-#[derive(Error, Debug, Eq, PartialEq)]
+#[derive(Error, Eq, PartialEq)]
 pub struct ParsingAmbiguityError {
-    on_tag_name: Box<str>,
+    cause: Cause,
+}
+
+impl ParsingAmbiguityError {
+    pub(crate) fn depth_exceeded() -> Self {
+        Self {
+            cause: Cause::DepthExceeded,
+        }
+    }
+}
+
+#[derive(Eq, PartialEq)]
+pub(crate) enum Cause {
+    AmbiguousTextTypeSwitch(Box<str>),
+    DepthExceeded,
+}
+
+impl Display for Cause {
+    #[cold]
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::AmbiguousTextTypeSwitch(on_tag_name) => write!(
+                f,
+                concat!(
+                    "The parser has encountered a text content tag (`<{}>`) in the context where it is ",
+                    "ambiguous whether this tag should be ignored or not. And, thus, it is unclear whether ",
+                    "consequent content should be parsed as raw text or HTML markup.",
+                    "\n\n",
+                    "This error occurs due to the limited capabilities of the streaming parsing. However, ",
+                    "almost all of the cases of this error are caused by a non-conforming markup (e.g. a ",
+                    "`<script>` element in `<select>` element)."
+                ),
+                on_tag_name
+            ),
+            Self::DepthExceeded => {
+                f.write_str("Too much HTML/XML nesting while simulating the tree builder.")
+            }
+        }
+    }
 }
 
 impl Display for ParsingAmbiguityError {
-    #[cold]
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(
-            f,
-            concat!(
-                "The parser has encountered a text content tag (`<{}>`) in the context where it is ",
-                "ambiguous whether this tag should be ignored or not. And, thus, it is unclear whether ",
-                "consequent content should be parsed as raw text or HTML markup.",
-                "\n\n",
-                "This error occurs due to the limited capabilities of the streaming parsing. However, ",
-                "almost all of the cases of this error are caused by a non-conforming markup (e.g. a ",
-                "`<script>` element in `<select>` element)."
-            ),
-            self.on_tag_name
-        )
+        Display::fmt(&self.cause, f)
+    }
+}
+
+impl fmt::Debug for ParsingAmbiguityError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        Display::fmt(&self.cause, f)
+    }
+}
+
+impl fmt::Debug for Cause {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        Display::fmt(self, f)
     }
 }
 
@@ -112,7 +149,7 @@ macro_rules! create_assert_for_tags {
         ) -> Result<(), ParsingAmbiguityError> {
             if tag_is_one_of!(tag_name, [ $($tag),+ ]) {
                 Err(ParsingAmbiguityError {
-                    on_tag_name: tag_hash_to_string(tag_name)
+                    cause: Cause::AmbiguousTextTypeSwitch(tag_hash_to_string(tag_name))
                 })
             } else {
                 Ok(())

--- a/src/parser/tree_builder_simulator/mod.rs
+++ b/src/parser/tree_builder_simulator/mod.rs
@@ -21,7 +21,8 @@ use TagTokenOutline::{EndTag, StartTag};
 
 pub use self::ambiguity_guard::ParsingAmbiguityError;
 
-const DEFAULT_NS_STACK_CAPACITY: usize = 256;
+/// <svg><html><svg><html>... nesting depth
+const MAX_NS_STACK_DEPTH: usize = 256;
 
 #[must_use]
 pub(crate) enum TreeBuilderFeedback {
@@ -29,6 +30,7 @@ pub(crate) enum TreeBuilderFeedback {
     SetAllowCdata(bool),
     #[allow(clippy::type_complexity)]
     RequestLexeme(Box<dyn FnMut(&mut TreeBuilderSimulator, &TagLexeme<'_>) -> Self + Send>),
+    DepthExceeded,
     None,
 }
 
@@ -112,7 +114,7 @@ impl TreeBuilderSimulator {
     #[must_use]
     pub fn new(strict: bool) -> Self {
         let mut simulator = Self {
-            ns_stack: Vec::with_capacity(DEFAULT_NS_STACK_CAPACITY),
+            ns_stack: Vec::with_capacity(MAX_NS_STACK_DEPTH),
             current_ns: Namespace::Html,
             ambiguity_guard: AmbiguityGuard::default(),
             strict,
@@ -179,6 +181,10 @@ impl TreeBuilderSimulator {
 
     #[inline]
     fn enter_ns(&mut self, ns: Namespace) -> TreeBuilderFeedback {
+        if self.ns_stack.len() >= self.ns_stack.capacity() {
+            return TreeBuilderFeedback::DepthExceeded;
+        }
+
         self.ns_stack.push(ns);
         self.current_ns = ns;
         TreeBuilderFeedback::SetAllowCdata(ns != Namespace::Html)

--- a/src/rewriter/mod.rs
+++ b/src/rewriter/mod.rs
@@ -724,6 +724,29 @@ mod tests {
     }
 
     #[test]
+    fn extra_svg_nesting() {
+        let nested = "<svg><foreign-content>".repeat(32);
+        let res = rewrite_str(
+            &nested,
+            RewriteStrSettings {
+                element_content_handlers: vec![element!("svg", |_| Ok(()))],
+                ..RewriteStrSettings::new()
+            },
+        );
+        assert_eq!(nested, res.unwrap());
+
+        let extra_nested = nested.repeat(32);
+        let res = rewrite_str(
+            &extra_nested,
+            RewriteStrSettings {
+                element_content_handlers: vec![element!("svg", |_| Ok(()))],
+                ..RewriteStrSettings::new()
+            },
+        );
+        assert!(matches!(res, Err(RewritingError::ParsingAmbiguity(_))));
+    }
+
+    #[test]
     fn handler_invocation_order() {
         let handlers_executed = Arc::new(Mutex::new(Vec::default()));
 


### PR DESCRIPTION
That stack (in a `Vec`) was technically unbounded, although not dangerous in practice due to tiny size of the enums.

This change puts a size limit on it, which rejects very suspicious documents that have `<svg>`s nested inside another `<svg>` with HTML foreign content sandwiched in between 256+ times. 