### PR TITLE
Serialize empty attribute values without `=""`

### DIFF
--- a/src/rewritable_units/element.rs
+++ b/src/rewritable_units/element.rs
@@ -1594,6 +1594,26 @@ mod tests {
         }
 
         #[test]
+        fn add_valueless_attr() {
+            test!(
+                |el| {
+                    el.set_attribute("a5", "").unwrap();
+                },
+                r#"<a a1='foo " baré " baz' a2="foo ' bar ' baz" a3=foo/bar a4 a5></a>"#
+            );
+        }
+
+        #[test]
+        fn clear_value_to_valueless_attr() {
+            test!(
+                |el| {
+                    el.set_attribute("a2", "").unwrap();
+                },
+                r#"<a a1='foo " baré " baz' a2 a3=foo/bar a4></a>"#
+            );
+        }
+
+        #[test]
         fn self_closing_flag() {
             // NOTE: we should add space between valueless attr and self-closing slash
             // during serialization. Otherwise, it will be interpreted as a part of the

--- a/src/rewritable_units/tokens/attributes.rs
+++ b/src/rewritable_units/tokens/attributes.rs
@@ -144,6 +144,8 @@ impl Serialize for &Attribute<'_> {
     fn into_bytes(self, output_handler: &mut dyn FnMut(&[u8])) -> Result<(), RewritingError> {
         if let Some(raw) = self.raw.as_ref() {
             output_handler(raw);
+        } else if self.value.is_empty() {
+            output_handler(&self.name);
         } else {
             output_handler(&self.name);
             output_handler(b"=\"");


### PR DESCRIPTION
When `Element::set_attribute` is called with an empty value, emit the attribute as a valueless attribute (e.g. `<p data-thing>`) rather than `<p data-thing="">`. 

The two are equivalent per the HTML spec, but the valueless form is what callers asking for "add a boolean attribute" expect to see in the output. Original raw attributes from the input are still emitted verbatim, so this only affects programmatically added/modified attributes.

Closes #205.