### PR TITLE
Fix selector matching being skipped for consecutive integration-point siblings

### DIFF
--- a/src/rewritable_units/element.rs
+++ b/src/rewritable_units/element.rs
@@ -978,6 +978,38 @@ mod tests {
     }
 
     #[test]
+    fn consecutive_svg_integration_points() {
+        // A tag hint that keeps the parser in scan mode must not leave
+        // `got_flags_from_hint` set: the next integration-point tag enters the
+        // lexer via tree-builder feedback without a hint of its own, and the
+        // stale flag would make `handle_tag` skip selector matching for it.
+        let out = rewrite_element(
+            b"<svg><desc>d</desc><title>t</title><foreignObject></foreignObject></svg>",
+            UTF_8,
+            "desc,title,foreignobject",
+            |el| el.set_attribute("hit", "").unwrap(),
+        );
+        assert_eq!(
+            out,
+            r#"<svg><desc hit="">d</desc><title hit="">t</title><foreignObject hit=""></foreignObject></svg>"#
+        );
+    }
+
+    #[test]
+    fn consecutive_math_ml_integration_points() {
+        let out = rewrite_element(
+            b"<math><mi>x</mi><mo>+</mo><mn>1</mn><annotation-xml></annotation-xml></math>",
+            UTF_8,
+            "mi,mo,mn,annotation-xml",
+            |el| el.set_attribute("hit", "").unwrap(),
+        );
+        assert_eq!(
+            out,
+            r#"<math><mi hit="">x</mi><mo hit="">+</mo><mn hit="">1</mn><annotation-xml hit=""></annotation-xml></math>"#
+        );
+    }
+
+    #[test]
     fn foreignobject() {
         let out = rewrite_element(
             br#"<svg><annotation-xml><foreignobject><style><!--</style><p id="--><img>">"#,

--- a/src/transform_stream/dispatcher.rs
+++ b/src/transform_stream/dispatcher.rs
@@ -376,8 +376,16 @@ where
         flags: TokenCaptureFlags,
     ) -> ParserDirective {
         self.delegate.capture_flags = flags;
-        self.got_flags_from_hint = true;
-        self.get_next_parser_directive()
+        let directive = self.get_next_parser_directive();
+        // NOTE: `got_flags_from_hint` tells the lexer's `handle_tag` that selector
+        // matching already ran for the tag it is about to emit. That is only true
+        // when the scanner is actually switching to the lexer for this tag. If the
+        // hint keeps us in scan mode we must clear it, otherwise a subsequent tag
+        // that enters the lexer via tree-builder `RequestLexeme` feedback (which
+        // emits no hint of its own) would inherit the stale flag and skip selector
+        // matching entirely.
+        self.got_flags_from_hint = matches!(directive, ParserDirective::Lex);
+        directive
     }
 
     /// Emit text chunk with is_last_in_node


### PR DESCRIPTION
## The bug

When two SVG/MathML integration-point elements are adjacent siblings, the second one never reaches selector matching. It is emitted to the output verbatim, but no element handler runs for it, including the universal selector:

```rust
// handler for "foreignobject" (or "*")
rewrite_str(r#"<svg><title>x</title><foreignObject></foreignObject></svg>"#, settings)
// handler fires for svg and title, never for foreignObject
```

Remove the `<title>` sibling and the same `foreignObject` matches fine. Intervening text does not re-arm matching; only an intervening non-integration-point element does. This makes selector-based sanitizers built on lol-html bypassable by prefixing the payload element with another integration-point sibling.

## The cause

The tag scanner emits a tag hint for most start tags; `Dispatcher::apply_capture_flags_from_hint_and_get_next_parser_directive` sets `got_flags_from_hint` so the lexer's `handle_tag` does not re-run selector matching for a tag the hint already matched. Integration-point start tags take a different path: the tree-builder simulator answers `RequestLexeme` (it needs `self_closing` to decide namespace entry) and the scanner switches to the lexer without emitting a hint.

If the previous tag's hint left the parser in scan mode (nothing to capture), `got_flags_from_hint` stayed `true`. The next `RequestLexeme` tag then reached `handle_tag` with the stale flag, so `adjust_capture_flags_for_tag_lexeme` was skipped and `handle_start_tag` never ran for it.

## The fix

The flag is only meaningful when the hint results in an immediate switch to the lexer for the same tag, so set it to `matches!(directive, ParserDirective::Lex)` instead of unconditionally `true`.

Two regression tests added next to the existing foreign-content tests in `rewritable_units/element.rs` (SVG `desc/title/foreignObject` and MathML `mi/mo/mn/annotation-xml` sibling chains); both fail on main and pass with the fix. `cargo test` and `cargo test --features=_integration_test` are green.

Found while debugging Bun's HTMLRewriter (oven-sh/bun#35673, ships this change as a vendored patch).