### PR TITLE
selectors_vm: make stray end tags and descendant matching linear in depth

### DIFF
--- a/src/html/local_name.rs
+++ b/src/html/local_name.rs
@@ -135,10 +135,22 @@ impl PartialEq<Tag> for LocalNameHash {
 /// `LocalName` is used for the comparison of tag names.
 /// In the majority of cases it will be represented as a hash, however for long
 /// non-standard tag names it fallsback to the Name representation.
-#[derive(Clone, Debug, Eq, Hash)]
+#[derive(Clone, Debug, Eq)]
 pub enum LocalName<'i> {
     Hash(LocalNameHash),
     Bytes(BytesCow<'i>),
+}
+
+// `PartialEq` compares `Bytes` case-insensitively, so `Hash` must case-fold too.
+impl std::hash::Hash for LocalName<'_> {
+    #[inline]
+    fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
+        core::mem::discriminant(self).hash(state);
+        match self {
+            LocalName::Hash(h) => h.hash(state),
+            LocalName::Bytes(b) => b.iter().for_each(|c| c.to_ascii_lowercase().hash(state)),
+        }
+    }
 }
 
 impl<'i> LocalName<'i> {
@@ -220,5 +232,16 @@ mod tests {
     #[test]
     fn hash_invalidation_for_long_values() {
         assert!(LocalNameHash::from("aaaaaaaaaaaaaa").is_empty());
+    }
+
+    #[test]
+    fn bytes_variant_hash_matches_case_insensitive_eq() {
+        use std::hash::{BuildHasher, RandomState};
+        let s = RandomState::new();
+        let a = LocalName::from_str_without_replacements("My-Widget", encoding_rs::UTF_8).unwrap();
+        let b = LocalName::from_str_without_replacements("my-widget", encoding_rs::UTF_8).unwrap();
+        assert!(matches!(a, LocalName::Bytes(_)));
+        assert_eq!(a, b);
+        assert_eq!(s.hash_one(&a), s.hash_one(&b));
     }
 }

--- a/src/selectors_vm/mod.rs
+++ b/src/selectors_vm/mod.rs
@@ -50,7 +50,6 @@ struct JumpPtr {
 
 #[derive(Default)]
 struct HereditaryJumpPtr {
-    stack_offset: usize,
     instr_set_idx: usize,
     offset: usize,
 }
@@ -425,22 +424,15 @@ where
         &self,
         ctx: &mut ExecutionCtx<'_, E>,
     ) -> Result<(), Bailout<HereditaryJumpPtr>> {
-        for (i, ancestor) in self.stack.items().iter().rev().enumerate() {
-            for (j, jumps) in ancestor.hereditary_jumps.iter().enumerate() {
-                self.try_exec_instr_set_without_attrs(jumps.clone(), ctx)
-                    .map_err(move |b| Bailout {
-                        at_addr: b.at_addr,
-                        recovery_point: HereditaryJumpPtr {
-                            stack_offset: i,
-                            instr_set_idx: j,
-                            offset: b.recovery_point,
-                        },
-                    })?;
-            }
-
-            if !ancestor.has_ancestor_with_hereditary_jumps {
-                break;
-            }
+        for (i, (jumps, _)) in self.stack.active_hereditary_jumps().iter().enumerate() {
+            self.try_exec_instr_set_without_attrs(jumps.clone(), ctx)
+                .map_err(move |b| Bailout {
+                    at_addr: b.at_addr,
+                    recovery_point: HereditaryJumpPtr {
+                        instr_set_idx: i,
+                        offset: b.recovery_point,
+                    },
+                })?;
         }
 
         Ok(())
@@ -452,41 +444,13 @@ where
         ctx: &mut ExecutionCtx<'_, E>,
         ptr: HereditaryJumpPtr,
     ) {
-        let items = self.stack.items();
+        let active = self.stack.active_hereditary_jumps();
 
-        if items.is_empty() {
-            return;
-        }
+        if let Some((ptr_jumps, _)) = active.get(ptr.instr_set_idx) {
+            self.exec_instr_set_with_attrs(ptr_jumps, attr_matcher, ctx, ptr.offset);
 
-        let ptr_ancestor_idx = items.len() - 1 - ptr.stack_offset;
-
-        // NOTE: first find pointed ancestor, then jump instruction
-        // set and execute it with the offset.
-        if let Some(ptr_ancestor) = items.get(ptr_ancestor_idx) {
-            if let Some(ptr_jumps) = ptr_ancestor.hereditary_jumps.get(ptr.instr_set_idx) {
-                self.exec_instr_set_with_attrs(ptr_jumps, attr_matcher, ctx, ptr.offset);
-
-                // NOTE: execute the rest of jump instruction sets in the pointed ancestor as usual.
-                for jumps in ptr_ancestor
-                    .hereditary_jumps
-                    .iter()
-                    .skip(ptr.instr_set_idx + 1)
-                {
-                    self.exec_instr_set_with_attrs(jumps, attr_matcher, ctx, 0);
-                }
-            }
-
-            // NOTE: execute hereditary jumps in remaining ancestors as usual.
-            if ptr_ancestor.has_ancestor_with_hereditary_jumps {
-                for ancestor in items.iter().rev().skip(ptr.stack_offset + 1) {
-                    for jumps in &ancestor.hereditary_jumps {
-                        self.exec_instr_set_with_attrs(jumps, attr_matcher, ctx, 0);
-                    }
-
-                    if !ancestor.has_ancestor_with_hereditary_jumps {
-                        break;
-                    }
-                }
+            for (jumps, _) in active.iter().skip(ptr.instr_set_idx + 1) {
+                self.exec_instr_set_with_attrs(jumps, attr_matcher, ctx, 0);
             }
         }
     }

--- a/src/selectors_vm/stack.rs
+++ b/src/selectors_vm/stack.rs
@@ -177,7 +177,6 @@ pub(crate) struct StackItem<'i, E: ElementData> {
     pub jumps: Vec<AddressRange>,
     pub hereditary_jumps: Vec<AddressRange>,
     pub child_counter: ChildCounter,
-    pub has_ancestor_with_hereditary_jumps: bool,
     pub stack_directive: StackDirective,
 }
 
@@ -191,7 +190,6 @@ impl<'i, E: ElementData> StackItem<'i, E> {
             jumps: Vec::default(),
             hereditary_jumps: Vec::default(),
             child_counter: Default::default(),
-            has_ancestor_with_hereditary_jumps: false,
             stack_directive: StackDirective::Push,
         }
     }
@@ -204,7 +202,6 @@ impl<'i, E: ElementData> StackItem<'i, E> {
             jumps: self.jumps,
             hereditary_jumps: self.hereditary_jumps,
             child_counter: self.child_counter,
-            has_ancestor_with_hereditary_jumps: self.has_ancestor_with_hereditary_jumps,
             stack_directive: self.stack_directive,
         }
     }
@@ -216,6 +213,10 @@ pub(crate) struct Stack<E: ElementData> {
     /// A typed counter for all elements on all frames. This is optional to indicate if types are actually being counted.
     typed_child_counters: Option<TypedChildCounterMap>,
     items: LimitedVec<StackItem<'static, E>>,
+    /// Per-name open-item counts so `pop_up_to` can reject a stray end tag in O(1).
+    open_name_counts: HashMap<LocalName<'static>, usize>,
+    /// Distinct hereditary-jump ranges from open items, with the shallowest depth that introduced each.
+    active_hereditary_jumps: Vec<(AddressRange, usize)>,
 }
 
 impl<E: ElementData> Stack<E> {
@@ -226,6 +227,8 @@ impl<E: ElementData> Stack<E> {
             root_child_counter: Default::default(),
             typed_child_counters: enable_nth_of_type.then(TypedChildCounterMap::new),
             items: LimitedVec::new(memory_limiter),
+            open_name_counts: HashMap::new(),
+            active_hereditary_jumps: Vec::new(),
         }
     }
 
@@ -281,8 +284,11 @@ impl<E: ElementData> Stack<E> {
     pub fn pop_up_to(
         &mut self,
         local_name: LocalName<'_>,
-        popped_element_data_handler: impl FnMut(E),
+        mut popped_element_data_handler: impl FnMut(E),
     ) {
+        if !self.open_name_counts.contains_key(&local_name) {
+            return;
+        }
         let pop_to_index = self
             .items
             .iter()
@@ -291,11 +297,27 @@ impl<E: ElementData> Stack<E> {
             if let Some(c) = self.typed_child_counters.as_mut() {
                 c.pop_to(index);
             }
-            self.items
-                .drain(index..)
-                .map(|i| i.element_data)
-                .for_each(popped_element_data_handler);
+            self.active_hereditary_jumps.retain(|(_, d)| *d < index);
+            for item in self.items.drain(index..) {
+                if let RawEntryMut::Occupied(mut e) = self
+                    .open_name_counts
+                    .raw_entry_mut()
+                    .from_key(&item.local_name)
+                {
+                    *e.get_mut() -= 1;
+                    if *e.get() == 0 {
+                        e.remove();
+                    }
+                }
+                popped_element_data_handler(item.element_data);
+            }
         }
+    }
+
+    #[inline]
+    #[must_use]
+    pub fn active_hereditary_jumps(&self) -> &[(AddressRange, usize)] {
+        &self.active_hereditary_jumps
     }
 
     #[inline]
@@ -312,15 +334,20 @@ impl<E: ElementData> Stack<E> {
     #[inline]
     pub fn push_item(
         &mut self,
-        mut item: StackItem<'static, E>,
+        item: StackItem<'static, E>,
     ) -> Result<(), MemoryLimitExceededError> {
-        if let Some(last) = self.items.last() {
-            if last.has_ancestor_with_hereditary_jumps || !last.hereditary_jumps.is_empty() {
-                item.has_ancestor_with_hereditary_jumps = true;
+        let depth = self.items.len();
+        self.items.push(item)?;
+        let item = self.items.last().expect("just pushed");
+        *self
+            .open_name_counts
+            .entry(item.local_name.clone())
+            .or_default() += 1;
+        for r in &item.hereditary_jumps {
+            if !self.active_hereditary_jumps.iter().any(|(a, _)| a == r) {
+                self.active_hereditary_jumps.push((r.clone(), depth));
             }
         }
-
-        self.items.push(item)?;
         Ok(())
     }
 }
@@ -356,31 +383,62 @@ mod tests {
         item
     }
 
+    fn active_hj(stack: &Stack<TestElementData>) -> Vec<AddressRange> {
+        stack
+            .active_hereditary_jumps()
+            .iter()
+            .map(|(r, _)| r.clone())
+            .collect()
+    }
+
     #[test]
-    #[allow(clippy::reversed_empty_ranges)]
-    fn hereditary_jumps_flag() {
+    fn active_hereditary_jumps_dedup_and_prune() {
         let mut stack = Stack::new(SharedMemoryLimiter::new(2048), false);
 
-        stack.push_item(item("item1", 0)).unwrap();
+        stack.push_item(item("a", 0)).unwrap();
 
-        let mut item2 = item("item2", 1);
-        item2.hereditary_jumps.push(0..0);
-        stack.push_item(item2).unwrap();
+        let mut b = item("b", 1);
+        b.hereditary_jumps.push(0..1);
+        stack.push_item(b).unwrap();
+        assert_eq!(active_hj(&stack), vec![0..1]);
 
-        let mut item3 = item("item3", 2);
-        item3.hereditary_jumps.push(0..0);
-        stack.push_item(item3).unwrap();
+        let mut c = item("c", 2);
+        c.hereditary_jumps.push(0..1);
+        c.hereditary_jumps.push(2..4);
+        stack.push_item(c).unwrap();
+        assert_eq!(active_hj(&stack), vec![0..1, 2..4]);
 
-        stack.push_item(item("item4", 3)).unwrap();
+        stack.push_item(item("d", 3)).unwrap();
+        assert_eq!(active_hj(&stack), vec![0..1, 2..4]);
 
-        assert_eq!(
-            stack
-                .items()
-                .iter()
-                .map(|i| i.has_ancestor_with_hereditary_jumps)
-                .collect::<Vec<_>>(),
-            [false, false, true, true]
-        );
+        stack.pop_up_to(local_name("c"), |_| {});
+        assert_eq!(active_hj(&stack), vec![0..1]);
+
+        stack.pop_up_to(local_name("a"), |_| {});
+        assert!(active_hj(&stack).is_empty());
+    }
+
+    #[test]
+    fn open_name_counts_track_push_and_drain() {
+        let mut stack = Stack::new(SharedMemoryLimiter::new(2048), false);
+
+        stack.push_item(item("a", 0)).unwrap();
+        stack.push_item(item("b", 1)).unwrap();
+        stack.push_item(item("a", 2)).unwrap();
+
+        stack.pop_up_to(local_name("c"), |_| unreachable!("should not pop"));
+        assert_eq!(stack.items().len(), 3);
+
+        let mut popped = Vec::new();
+        stack.pop_up_to(local_name("a"), |d| popped.push(d.0));
+        assert_eq!(popped, vec![2]);
+        assert_eq!(stack.items().len(), 2);
+
+        stack.pop_up_to(local_name("a"), |d| popped.push(d.0));
+        assert_eq!(popped, vec![2, 0, 1]);
+        assert!(stack.items().is_empty());
+
+        stack.pop_up_to(local_name("a"), |_| unreachable!("stack is empty"));
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Fixes two per-token scans in the selector-VM open-element stack that go quadratic (or worse) on pathological nesting, plus a `LocalName` `Hash`/`Eq` contract violation that the fix surfaced.

## Repro

```rust
use lol_html::{rewrite_str, RewriteStrSettings, element};

// (1) stray end tags: O(depth) reverse scan per end tag
let doc = "<a></b>".repeat(100_000);               // ~700 KB
rewrite_str(&doc, RewriteStrSettings {
    element_content_handlers: vec![element!("nomatch", |_| Ok(()))],
    ..Default::default()
}).unwrap();
// before: ~25 s of one core; after: tens of ms

// (2) descendant combinator over deep matching nesting: O(depth) ancestor walk per start tag
let deep = "<div>".repeat(40_000) + &"</div>".repeat(40_000);   // ~440 KB
rewrite_str(&deep, RewriteStrSettings {
    element_content_handlers: vec![element!("div div", |_| Ok(()))],
    ..Default::default()
}).unwrap();
// before: ~30 s; after: tens of ms
// with "div div div" the old behaviour is cubic: depth 4000 ≈ 3.5 CPU-min for a 44 KB doc
```

Any element (or text/comments) handler registration enables the selector VM, so untrusted HTML can pin a CPU core via sub-MB input. Memory stays linear, so `max_allowed_memory_usage` does not bound it.

## Cause

* `Stack::pop_up_to` does `items.iter().rposition(|i| i.local_name == name)` for every end tag. A stray end tag that matches nothing still scans the entire open stack: N unclosed opens plus N stray closes is N full scans.
* `try_exec_hereditary_jumps_without_attrs` walks every ancestor's `hereditary_jumps` for every start tag. For `div div` over N nested `<div>`, every item carries the same address range so the walk is O(depth) per tag; for k-arm descendant chains it compounds to O(depth^k).

## Fix

`Stack` now maintains:

* `open_name_counts: HashMap<LocalName, usize>` so `pop_up_to` rejects a name not on the stack in O(1). When the name is present the `rposition` scan length equals the subsequent drain length, so total scan work over a document is bounded by total pushes.
* `active_hereditary_jumps: Vec<(AddressRange, usize)>`, the distinct hereditary-jump ranges currently contributed by any open item, each paired with the shallowest depth that introduced it. Descendant matching iterates this flat list (bounded by program size, not depth); `pop_up_to` prunes it by depth. The per-item `has_ancestor_with_hereditary_jumps` flag and the `HereditaryJumpPtr.stack_offset` resume coordinate are removed.

Re-executing the same address range against the same start tag was already a no-op after the matched-id set union in `add_execution_branch`, so dedup-once execution is observationally equivalent.

`LocalName` now has a manual `Hash` impl that ASCII-lowercases the `Bytes` arm, so it agrees with the existing case-insensitive `PartialEq`. Without this, keying a `HashMap` on `LocalName` is unsound for any name that falls off `LocalNameHash` (custom elements, >12 chars, chars outside `a-zA-Z1-6`); the new `open_name_counts` map made that latent bug observable, and it also affects the existing `TypedChildCounterMap` used for `:nth-of-type`.

## Tests

* `cargo test --lib`: 180 passed (including new `active_hereditary_jumps_dedup_and_prune`, `open_name_counts_track_push_and_drain`, `bytes_variant_hash_matches_case_insensitive_eq`).
* `cargo test --features _integration_test`: 3 passed (token capturing, element content replacement, selector matching fixtures).
* `cargo clippy --all-targets`: clean.