### PR TITLE
Match attribute selector names ASCII case-insensitively

### DIFF
--- a/src/selectors_vm/ast.rs
+++ b/src/selectors_vm/ast.rs
@@ -1,6 +1,6 @@
 use super::parser::{Selector, SelectorImplDescriptor};
 use crate::selectors_vm::{DenseHashSet, MatchId};
-use selectors::attr::{AttrSelectorOperator, ParsedCaseSensitivity};
+use selectors::attr::{AttrSelectorOperator, ParsedAttrSelectorOperation, ParsedCaseSensitivity};
 use selectors::parser::{Combinator, Component, NthType};
 use std::fmt::{self, Debug, Formatter};
 
@@ -123,9 +123,11 @@ impl From<&Component<SelectorImplDescriptor>> for Condition {
             Component::ExplicitNoNamespace => Self::OnTagName(OnTagNameExpr::Unmatchable),
             Component::ID(id) => Self::OnAttributes(OnAttributesExpr::Id(id.to_boxed_slice())),
             Component::Class(c) => Self::OnAttributes(OnAttributesExpr::Class(c.to_boxed_slice())),
-            Component::AttributeInNoNamespaceExists { local_name, .. } => Self::OnAttributes(
-                OnAttributesExpr::AttributeExists(local_name.to_boxed_slice()),
-            ),
+            Component::AttributeInNoNamespaceExists {
+                local_name_lower, ..
+            } => Self::OnAttributes(OnAttributesExpr::AttributeExists(
+                local_name_lower.to_boxed_slice(),
+            )),
             &Component::AttributeInNoNamespace {
                 ref local_name,
                 ref value,
@@ -139,6 +141,23 @@ impl From<&Component<SelectorImplDescriptor>> for Condition {
                     operator,
                 ),
             )),
+            Component::AttributeOther(attr) if attr.namespace.is_none() => {
+                Self::OnAttributes(match &attr.operation {
+                    ParsedAttrSelectorOperation::Exists => {
+                        OnAttributesExpr::AttributeExists(attr.local_name_lower.to_boxed_slice())
+                    }
+                    ParsedAttrSelectorOperation::WithValue {
+                        operator,
+                        case_sensitivity,
+                        value,
+                    } => OnAttributesExpr::AttributeComparisonExpr(AttributeComparisonExpr::new(
+                        attr.local_name_lower.to_boxed_slice(),
+                        value.to_boxed_slice(),
+                        *case_sensitivity,
+                        *operator,
+                    )),
+                })
+            }
             Component::Nth(data) if data.ty == NthType::Child => Self::OnTagName(
                 OnTagNameExpr::NthChild(NthChild::new(data.an_plus_b.0, data.an_plus_b.1)),
             ),
@@ -407,7 +426,28 @@ mod tests {
                 },
             ),
             (
+                "[FOO]",
+                Expr {
+                    simple_expr: OnAttributesExpr::AttributeExists("foo".into()),
+                    negation: false,
+                },
+            ),
+            (
                 r#"[foo="bar"]"#,
+                Expr {
+                    simple_expr: OnAttributesExpr::AttributeComparisonExpr(
+                        AttributeComparisonExpr {
+                            name: "foo".into(),
+                            value: "bar".into(),
+                            case_sensitivity: ParsedCaseSensitivity::CaseSensitive,
+                            operator: AttrSelectorOperator::Equal,
+                        },
+                    ),
+                    negation: false,
+                },
+            ),
+            (
+                r#"[FOO="bar"]"#,
                 Expr {
                     simple_expr: OnAttributesExpr::AttributeComparisonExpr(
                         AttributeComparisonExpr {
@@ -821,6 +861,8 @@ mod tests {
             SelectorError::UnexpectedTokenInAttribute,
         );
         assert_err("svg|img", SelectorError::NamespacedSelector);
+        assert_err("[*|Foo]", SelectorError::NamespacedSelector);
+        assert_err("[*|Foo=bar]", SelectorError::NamespacedSelector);
         assert_err(".foo()", SelectorError::InvalidClassName);
         assert_err(":not()", SelectorError::EmptySelector);
         assert_err("div + span", SelectorError::UnsupportedCombinator('+'));

--- a/src/selectors_vm/parser.rs
+++ b/src/selectors_vm/parser.rs
@@ -150,6 +150,7 @@ impl SelectorsParser {
             | Component::Class(_)
             | Component::AttributeInNoNamespaceExists { .. }
             | Component::AttributeInNoNamespace { .. } => Ok(()),
+            Component::AttributeOther(attr) if attr.namespace.is_none() => Ok(()),
 
             Component::Nth(data) => Self::validate_nth(data),
 

--- a/src/selectors_vm/tests.rs
+++ b/src/selectors_vm/tests.rs
@@ -1681,6 +1681,23 @@ mod compiler {
             );
 
             assert_attr_expr_matches_and_negation_reverses_match(
+                "[FOO]",
+                encoding,
+                &[("<div foo>", true), ("<div FOO=1>", true), ("<div>", false)],
+            );
+
+            assert_attr_expr_matches_and_negation_reverses_match(
+                r#"[FOO="bar"]"#,
+                encoding,
+                &[
+                    ("<div foo='bar'>", true),
+                    ("<div FOO='bar'>", true),
+                    ("<div foo='BAR'>", false),
+                    ("<div>", false),
+                ],
+            );
+
+            assert_attr_expr_matches_and_negation_reverses_match(
                 r#"[foo="barα"]"#,
                 encoding,
                 &[


### PR DESCRIPTION
Fixes #328.

`[HREF]` was accepted but silently matched nothing: `Condition::from` stored `local_name` (the selector as written) while `AttributeMatcher::find` compares against lowercased element attribute names. Use `local_name_lower` instead.

`[HREF=x]` threw `NamespacedSelector`: the `selectors` crate emits `Component::AttributeOther` for any attribute name that isn't already ASCII-lowercase (`namespace.is_some() || !local_name_is_ascii_lowercase`), and `validate_component` rejected every `AttributeOther` without checking whether a namespace is present. Accept it when `namespace` is `None` and lower it to the existing `AttributeExists`/`AttributeComparisonExpr` expressions using `local_name_lower`.

Selectors with an actual namespace (`[*|foo]`) are still rejected.